### PR TITLE
Implement tmp::path::release method

### DIFF
--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -26,6 +26,11 @@ public:
     /// @returns A pointer to the path owned by *this
     const std::filesystem::path* operator->() const noexcept;
 
+    /// Releases the ownership of the managed path;
+    /// the destructor will not delete the managed path after the call
+    /// @returns The managed path
+    std::filesystem::path release() noexcept;
+
     /// Deletes the managed path recursively if it is not empty
     virtual ~path() noexcept;
 

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -24,14 +24,11 @@ path::path(fs::path path)
     : underlying(std::move(path)) {}
 
 path::path(path&& other) noexcept
-    : underlying(std::move(other.underlying)) {
-    other.underlying.clear();
-}
+    : underlying(other.release()) {}
 
 path& path::operator=(path&& other) noexcept {
     remove(*this);
-    underlying = std::move(other.underlying);
-    other.underlying.clear();
+    underlying = other.release();
     return *this;
 }
 
@@ -45,6 +42,12 @@ path::operator const fs::path&() const noexcept {
 
 const fs::path* path::operator->() const noexcept {
     return std::addressof(underlying);
+}
+
+fs::path path::release() noexcept {
+    fs::path path = std::move(underlying);
+    underlying.clear();
+    return path;
 }
 
 fs::path path::make_pattern(std::string_view prefix) {

--- a/tests/directory_test.cpp
+++ b/tests/directory_test.cpp
@@ -43,6 +43,20 @@ TEST(DirectoryTest, SubpathTest) {
     ASSERT_EQ(fs::path(tmpdir), child.parent_path());
 }
 
+TEST(DirectoryTest, Release) {
+    auto path = fs::path();
+    {
+        auto tmpdir = tmp::directory(PREFIX);
+        auto expected = fs::path(tmpdir);
+        path = tmpdir.release();
+        ASSERT_EQ(path, expected);
+        ASSERT_TRUE(fs::exists(path));
+    }
+
+    ASSERT_TRUE(fs::exists(path));
+    fs::remove(path);
+}
+
 TEST(DirectoryTest, MoveConstruction) {
     auto fst = tmp::directory(PREFIX);
     const auto snd = std::move(fst);

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -16,7 +16,7 @@ TEST(FileTest, CreateFile) {
     }
 }
 
-TEST(FileTest, RemoveDirectory) {
+TEST(FileTest, RemoveFile) {
     auto path = fs::path();
     {
         const auto tmpfile = tmp::file(PREFIX);
@@ -35,6 +35,20 @@ TEST(FileTest, CreateMultiple) {
     ASSERT_TRUE(fs::exists(snd));
 
     EXPECT_NE(fs::path(fst), fs::path(snd));
+}
+
+TEST(FileTest, Release) {
+    auto path = fs::path();
+    {
+        auto tmpfile = tmp::file(PREFIX);
+        auto expected = fs::path(tmpfile);
+        path = tmpfile.release();
+        ASSERT_EQ(path, expected);
+        ASSERT_TRUE(fs::exists(path));
+    }
+
+    ASSERT_TRUE(fs::exists(path));
+    fs::remove(path);
 }
 
 TEST(FileTest, MoveConstruction) {


### PR DESCRIPTION
Implement tmp::path::release, which releases the ownership of the managed path