### PR TITLE
Add tmp::path::move

### DIFF
--- a/include/tmp/path
+++ b/include/tmp/path
@@ -31,6 +31,12 @@ public:
     /// @returns The managed path
     std::filesystem::path release() noexcept;
 
+    /// Moves the managed path recursively to a given target, releasing
+    /// ownership of the managed path
+    /// @param to   A path to the target file or directory
+    /// @throws std::filesystem::filesystem_error if cannot move the owned path
+    void move(const std::filesystem::path& to);
+
     /// Deletes the managed path recursively if it is not empty
     virtual ~path() noexcept;
 
@@ -48,7 +54,7 @@ public:
     /// The parent of the resulting path is created when this function is called
     /// @param prefix   A prefix to be used in the path pattern
     /// @returns A path pattern for the unique temporary path
-    /// @throws std::filesystem::filesystem_error if failed to create the parent
+    /// @throws std::filesystem::filesystem_error if cannot create the parent
     static std::filesystem::path make_pattern(std::string_view prefix);
 
 protected:

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -8,6 +8,10 @@ namespace fs = std::filesystem;
 
 namespace {
 
+/// Options for recursive overwriting coping
+const fs::copy_options copy_options = fs::copy_options::recursive
+                                    | fs::copy_options::overwrite_existing;
+
 /// Deletes the given path recursively, ignoring any errors
 /// @param path The path of the directory to remove
 void remove(const tmp::path& path) noexcept {
@@ -48,6 +52,21 @@ fs::path path::release() noexcept {
     fs::path path = std::move(underlying);
     underlying.clear();
     return path;
+}
+
+void path::move(const fs::path& to) {
+    std::error_code ec;
+    fs::rename(*this, to, ec);
+    if (ec == std::errc::cross_device_link) {
+        fs::copy(*this, to, copy_options, ec);
+    }
+
+    if (ec) {
+        throw fs::filesystem_error("Cannot move temporary resource", to, ec);
+    }
+
+    remove(*this);
+    release();
 }
 
 fs::path path::make_pattern(std::string_view prefix) {

--- a/tests/directory_test.cpp
+++ b/tests/directory_test.cpp
@@ -57,6 +57,21 @@ TEST(DirectoryTest, Release) {
     fs::remove(path);
 }
 
+TEST(DirectoryTest, MoveDirectory) {
+    auto path = fs::path();
+    auto to = fs::temp_directory_path() / PREFIX / "moved";
+    {
+        auto tmpdir = tmp::directory(PREFIX);
+        path = tmpdir;
+
+        tmpdir.move(to);
+    }
+
+    ASSERT_FALSE(fs::exists(path));
+    ASSERT_TRUE(fs::exists(to));
+    fs::remove_all(to);
+}
+
 TEST(DirectoryTest, MoveConstruction) {
     auto fst = tmp::directory(PREFIX);
     const auto snd = std::move(fst);

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -51,6 +51,21 @@ TEST(FileTest, Release) {
     fs::remove(path);
 }
 
+TEST(FileTest, MoveFile) {
+    auto path = fs::path();
+    auto to = fs::temp_directory_path() / PREFIX / "moved";
+    {
+        auto tmpfile = tmp::file(PREFIX);
+        path = tmpfile;
+
+        tmpfile.move(to);
+    }
+
+    ASSERT_FALSE(fs::exists(path));
+    ASSERT_TRUE(fs::exists(to));
+    fs::remove_all(to);
+}
+
 TEST(FileTest, MoveConstruction) {
     auto fst = tmp::file(PREFIX);
     const auto snd = std::move(fst);


### PR DESCRIPTION
Add a tmp::path::move method which moves the managed path to the given target:
```cpp
/// Moves the managed path recursively to a given target, releasing
/// ownership of the managed path
/// @param to   A path to the target file or directory
/// @throws std::filesystem::filesystem_error if cannot move the owned path
void move(const std::filesystem::path& to);
```