### PR TITLE
tmp::path::move creates parent directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ auto tmpfile = tmp::file("org.example.product");
 tmpfile.write(data);
 
 if (validate_metadata(tmpfile)) {
-  fs::copy(tmpfile, storage);
+  tmpfile.move(storage / "new_file");
 } else {
   throw InvalidRequestError();
 }

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -33,6 +33,8 @@ public:
 
     /// Moves the managed path recursively to a given target, releasing
     /// ownership of the managed path
+    ///
+    /// The parent of the target path is created when this function is called
     /// @param to   A path to the target file or directory
     /// @throws std::filesystem::filesystem_error if cannot move the owned path
     void move(const std::filesystem::path& to);

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -56,6 +56,7 @@ fs::path path::release() noexcept {
 
 void path::move(const fs::path& to) {
     std::error_code ec;
+    fs::create_directories(to.parent_path(), ec);
     fs::rename(*this, to, ec);
     if (ec == std::errc::cross_device_link) {
         fs::copy(*this, to, copy_options, ec);

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -55,8 +55,9 @@ fs::path path::release() noexcept {
 }
 
 void path::move(const fs::path& to) {
-    std::error_code ec;
     fs::create_directories(to.parent_path());
+
+    std::error_code ec;
     fs::rename(*this, to, ec);
     if (ec == std::errc::cross_device_link) {
         fs::copy(*this, to, copy_options, ec);

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -56,7 +56,7 @@ fs::path path::release() noexcept {
 
 void path::move(const fs::path& to) {
     std::error_code ec;
-    fs::create_directories(to.parent_path(), ec);
+    fs::create_directories(to.parent_path());
     fs::rename(*this, to, ec);
     if (ec == std::errc::cross_device_link) {
         fs::copy(*this, to, copy_options, ec);

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -53,7 +53,7 @@ TEST(FileTest, Release) {
 
 TEST(FileTest, MoveFile) {
     auto path = fs::path();
-    auto to = fs::temp_directory_path() / PREFIX / "moved";
+    auto to = fs::temp_directory_path() / PREFIX / "non-existing" / "parent";
     {
         auto tmpfile = tmp::file(PREFIX);
         path = tmpfile;
@@ -63,7 +63,7 @@ TEST(FileTest, MoveFile) {
 
     ASSERT_FALSE(fs::exists(path));
     ASSERT_TRUE(fs::exists(to));
-    fs::remove_all(to);
+    fs::remove_all(fs::temp_directory_path() / PREFIX / "non-existing");
 }
 
 TEST(FileTest, MoveConstruction) {


### PR DESCRIPTION
Make `tmp::path::move` to create the parent directories of the given target if they do not exist