### PR TITLE
Fix a bug with moving between devices

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -14,6 +14,7 @@ const fs::copy_options copy_options = fs::copy_options::recursive
 
 /// Creates the parent directory of the given path if it does not exist
 /// @param path The path for which the parent directory needs to be created
+/// @throws fs::filesystem_error if cannot create the parent
 void create_parent(const fs::path& path) {
     fs::create_directories(path.parent_path());
 }
@@ -66,6 +67,12 @@ void path::move(const fs::path& to) {
     std::error_code ec;
     fs::rename(*this, to, ec);
     if (ec == std::errc::cross_device_link) {
+        if (fs::is_regular_file(*this) && fs::is_directory(to)) {
+            ec = std::make_error_code(std::errc::is_a_directory);
+            throw fs::filesystem_error("Cannot move temporary file", to, ec);
+        }
+
+        fs::remove_all(to);
         fs::copy(*this, to, copy_options, ec);
     }
 

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -32,6 +32,7 @@ void remove(const tmp::path& path) noexcept {
 /// moved to the specified path
 /// @param to   The target path where the resource was intended to be moved
 /// @param ec   The error code associated with the failure to move the resource
+/// @throws fs::filesystem_error when called
 [[noreturn]] void throw_move_error(const fs::path& to, std::error_code ec) {
     throw fs::filesystem_error("Cannot move temporary resource", to, ec);
 }

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -27,6 +27,14 @@ void remove(const tmp::path& path) noexcept {
         fs::remove_all(path, ec);
     }
 }
+
+/// Throws a filesystem error indicating that a temporary resource cannot be
+/// moved to the specified path
+/// @param to   The target path where the resource was intended to be moved
+/// @param ec   The error code associated with the failure to move the resource
+[[noreturn]] void throw_move_error(const fs::path& to, std::error_code ec) {
+    throw fs::filesystem_error("Cannot move temporary resource", to, ec);
+}
 }    // namespace
 
 namespace tmp {
@@ -69,7 +77,7 @@ void path::move(const fs::path& to) {
     if (ec == std::errc::cross_device_link) {
         if (fs::is_regular_file(*this) && fs::is_directory(to)) {
             ec = std::make_error_code(std::errc::is_a_directory);
-            throw fs::filesystem_error("Cannot move temporary file", to, ec);
+            throw_move_error(to, ec);
         }
 
         fs::remove_all(to);
@@ -77,7 +85,7 @@ void path::move(const fs::path& to) {
     }
 
     if (ec) {
-        throw fs::filesystem_error("Cannot move temporary resource", to, ec);
+        throw_move_error(to, ec);
     }
 
     remove(*this);


### PR DESCRIPTION
Fixed an issue where moving between devices would behave differently than on the same device:
- If moving between devices, fail if source is the file and target is a directory
- Remove the target recursively before copying over it