### PR TITLE
Add tmp::file::slurp method

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -58,9 +58,13 @@ public:
     /// @throws std::filesystem::filesystem_error if cannot create a file
     static file text(std::string_view prefix = "");
 
-    /// Reads the contents of this file
+    /// Streams the contents of this file
     /// @returns A file stream with this file contents
     std::ifstream read() const;
+
+    /// Reads this file contents into a string
+    /// @returns A string with this file contents
+    std::string slurp() const;
 
     /// Writes the given content to this file discarding any previous content
     /// @param content  A string to write to this file

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -62,7 +62,7 @@ public:
     /// @returns A file stream with this file contents
     std::ifstream read() const;
 
-    /// Reads this file contents into a string
+    /// Reads the entire contents of this file
     /// @returns A string with this file contents
     std::string slurp() const;
 

--- a/lib/file.cpp
+++ b/lib/file.cpp
@@ -60,6 +60,11 @@ std::ifstream file::read() const {
         : std::ifstream(file);
 }
 
+std::string file::slurp() const {
+    auto stream = read();
+    return std::string(std::istreambuf_iterator<char>(stream), {});
+}
+
 void file::write(std::string_view content) const {
     stream(*this, binary, /*append=*/false) << content;
 }

--- a/lib/file.cpp
+++ b/lib/file.cpp
@@ -61,7 +61,7 @@ std::ifstream file::read() const {
 }
 
 std::string file::slurp() const {
-    auto stream = read();
+    std::ifstream stream = read();
     return std::string(std::istreambuf_iterator<char>(stream), {});
 }
 

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -101,6 +101,15 @@ TEST(FileTest, Read) {
     ASSERT_EQ(content, "Hello, world!");
 }
 
+TEST(FileTest, Slurp) {
+    const auto tmpfile = tmp::file(PREFIX);
+    tmpfile.write("Hello");
+    tmpfile.append(", world!");
+
+    auto content = tmpfile.slurp();
+    ASSERT_EQ(content, "Hello, world!");
+}
+
 TEST(FileTest, Write) {
     const auto tmpfile = tmp::file(PREFIX);
     tmpfile.write("Hello");


### PR DESCRIPTION
Implement tmp::file::slurp method, which returns the entire contents for the file in a form of a string