### PR TITLE
Explicitly define used filesystem library

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -42,7 +42,7 @@ public:
     /// the given prefix, and random characters to ensure path uniqueness
     ///
     /// @param prefix   A prefix to be used in the temporary directory path
-    /// @throws std::filesystem::filesystem_error if cannot create a directory
+    /// @throws fs::filesystem_error if cannot create a directory
     explicit directory(std::string_view prefix = "");
 
     /// Creates a unique temporary copy recursively from the given path
@@ -50,13 +50,13 @@ public:
     /// @param path   A path to make a temporary copy from
     /// @param prefix A prefix to be used in the temporary directory path
     /// @return The new temporary directory
-    /// @throws std::filesystem::filesystem_error if the given path is not a directory
-    static directory copy(const std::filesystem::path& path, std::string_view prefix = "");
+    /// @throws fs::filesystem_error if the given path is not a directory
+    static directory copy(const fs::path& path, std::string_view prefix = "");
 
     /// Concatenates this directory path with a given @p source
     /// @param source   A string which represents a path name
     /// @returns The result of path concatenation
-    std::filesystem::path operator/(std::string_view source) const;
+    fs::path operator/(std::string_view source) const;
 
     /// Deletes the managed directory recursively if its path is not empty
     ~directory() noexcept override;

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -47,7 +47,7 @@ public:
     /// given prefix, and random characters to ensure path uniqueness
     ///
     /// @param prefix   A prefix to be used in the temporary file path
-    /// @throws std::filesystem::filesystem_error if cannot create a file
+    /// @throws fs::filesystem_error if cannot create a file
     explicit file(std::string_view prefix = "");
 
     /// Creates a unique temporary text file
@@ -56,7 +56,7 @@ public:
     /// given prefix, and random characters to ensure path uniqueness
     ///
     /// @param prefix   A prefix to be used in the temporary file path
-    /// @throws std::filesystem::filesystem_error if cannot create a file
+    /// @throws fs::filesystem_error if cannot create a file
     static file text(std::string_view prefix = "");
 
     /// Creates a unique temporary copy from the given path
@@ -64,8 +64,8 @@ public:
     /// @param path   A path to make a temporary copy from
     /// @param prefix A prefix to be used in the temporary directory path
     /// @return The new temporary file
-    /// @throws std::filesystem::filesystem_error if the given path is not a regular file
-    static file copy(const std::filesystem::path& path, std::string_view prefix = "");
+    /// @throws fs::filesystem_error if the given path is not a regular file
+    static file copy(const fs::path& path, std::string_view prefix = "");
 
     /// Streams the contents of this file
     /// @returns A file stream with this file contents
@@ -102,7 +102,7 @@ private:
     ///
     /// @param prefix   A prefix to be used in the temporary file path
     /// @param binary   Whether the managed file is opened in binary write mode
-    /// @throws std::filesystem::filesystem_error if cannot create a file
+    /// @throws fs::filesystem_error if cannot create a file
     explicit file(std::string_view prefix, bool binary);
 };
 }    // namespace tmp

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -5,6 +5,9 @@
 
 namespace tmp {
 
+/// The filesystem library to use
+namespace fs = std::filesystem;
+
 /// tmp::path is a smart handle that owns and manages a temporary path and
 /// deletes it recursively when this handle goes out of scope
 ///
@@ -13,28 +16,28 @@ namespace tmp {
 /// - the managing tmp::path object is assigned another path via operator=
 class path {
     /// The managed path
-    std::filesystem::path underlying;
+    fs::path underlying;
 
 public:
     /// Returns the managed path
-    operator const std::filesystem::path&() const noexcept;
+    operator const fs::path&() const noexcept;
 
     /// Dereferences the managed path
     /// @returns A pointer to the path owned by *this
-    const std::filesystem::path* operator->() const noexcept;
+    const fs::path* operator->() const noexcept;
 
     /// Releases the ownership of the managed path;
     /// the destructor will not delete the managed path after the call
     /// @returns The managed path
-    std::filesystem::path release() noexcept;
+    fs::path release() noexcept;
 
     /// Moves the managed path recursively to a given target, releasing
     /// ownership of the managed path
     ///
     /// The parent of the target path is created when this function is called
     /// @param to   A path to the target file or directory
-    /// @throws std::filesystem::filesystem_error if cannot move the owned path
-    void move(const std::filesystem::path& to);
+    /// @throws fs::filesystem_error if cannot move the owned path
+    void move(const fs::path& to);
 
     /// Deletes the managed path recursively if it is not empty
     virtual ~path() noexcept;
@@ -47,6 +50,6 @@ public:
 protected:
     /// Constructs a tmp::path which owns @p path
     /// @param path A path to manage
-    explicit path(std::filesystem::path path);
+    explicit path(fs::path path);
 };
 }    // namespace tmp

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -10,7 +10,7 @@
 #include <unistd.h>
 #include <utility>
 
-namespace fs = std::filesystem;
+namespace tmp {
 
 namespace {
 
@@ -27,7 +27,7 @@ void create_parent(const fs::path& path) {
 
 /// Deletes the given path recursively, ignoring any errors
 /// @param path The path to remove recursively
-void remove(const tmp::path& path) noexcept {
+void remove(const path& path) noexcept {
     if (!path->empty()) {
         std::error_code ec;
         fs::remove_all(path, ec);
@@ -95,7 +95,7 @@ fs::path create_directory(std::string_view prefix) {
 /// @param binary   Whether to open the file in binary mode
 /// @param append   Whether to append to the end of the file
 /// @returns An output file stream
-std::ofstream stream(const tmp::file& file, bool binary, bool append) noexcept {
+std::ofstream stream(const file& file, bool binary, bool append) noexcept {
     std::ios::openmode mode = append ? std::ios::app : std::ios::trunc;
     if (binary) {
         mode |= std::ios::binary;
@@ -105,8 +105,6 @@ std::ofstream stream(const tmp::file& file, bool binary, bool append) noexcept {
 }
 }    // namespace
 
-
-namespace tmp {
 
 //===----------------------------------------------------------------------===//
 // tmp::path implementation

--- a/tests/directory_test.cpp
+++ b/tests/directory_test.cpp
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 #include <tmp/file>
 
-namespace fs = std::filesystem;
+namespace fs = tmp::fs;
 
 TEST(DirectoryTest, CreateDirectory) {
     {

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -4,7 +4,7 @@
 #include <tmp/directory>
 #include <fstream>
 
-namespace fs = std::filesystem;
+namespace fs = tmp::fs;
 
 TEST(FileTest, CreateFile) {
     {


### PR DESCRIPTION
Specify an alias for the filesystem namespace so that you can later replace it with compatible libraries