### PR TITLE
Move tmp::fs definition to a separate file

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <tmp/fs>
 #include <tmp/path>
 
-#include <filesystem>
 #include <string_view>
 
 namespace tmp {

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <tmp/fs>
 #include <tmp/path>
 
-#include <filesystem>
 #include <fstream>
 #include <string>
 #include <string_view>

--- a/include/tmp/fs
+++ b/include/tmp/fs
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <filesystem>
+
+namespace tmp {
+
+/// The filesystem library to use
+namespace fs = std::filesystem;
+}    // namespace tmp

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -1,12 +1,11 @@
 #pragma once
 
+#include <tmp/fs>
+
 #include <filesystem>
 #include <string_view>
 
 namespace tmp {
-
-/// The filesystem library to use
-namespace fs = std::filesystem;
 
 /// tmp::path is a smart handle that owns and manages a temporary path and
 /// deletes it recursively when this handle goes out of scope

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -1,5 +1,5 @@
+#include <tmp/fs>
 #include <tmp/path>
-
 #include <tmp/file>
 #include <tmp/directory>
 

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -3,7 +3,6 @@
 #include <tmp/file>
 #include <tmp/directory>
 
-#include <filesystem>
 #include <fstream>
 #include <string_view>
 #include <system_error>


### PR DESCRIPTION
Follow the "one file per top-level definition" style guide

- Move tmp::fs definition to a separate file
- Remove <filesystem> include