### PR TITLE
Unify read and slurp methods

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -68,13 +68,9 @@ public:
     static file copy(const std::filesystem::path& path,
                      std::string_view prefix = "");
 
-    /// Streams the contents of this file
-    /// @returns A file stream with this file contents
-    std::ifstream read() const;
-
     /// Reads the entire contents of this file
     /// @returns A string with this file contents
-    std::string slurp() const;
+    std::string read() const;
 
     /// Writes the given content to this file discarding any previous content
     /// @param content  A string to write to this file

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -182,13 +182,11 @@ file file::copy(const fs::path& path, std::string_view prefix) {
     return tmpfile;
 }
 
-std::ifstream file::read() const {
+std::string file::read() const {
     const fs::path& file = *this;
-    return binary ? std::ifstream(file, std::ios::binary) : std::ifstream(file);
-}
+    std::ifstream stream =
+        binary ? std::ifstream(file, std::ios::binary) : std::ifstream(file);
 
-std::string file::slurp() const {
-    std::ifstream stream = read();
     return std::string(std::istreambuf_iterator<char>(stream), {});
 }
 

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -184,9 +184,9 @@ file file::copy(const fs::path& path, std::string_view prefix) {
 
 std::string file::read() const {
     const fs::path& file = *this;
-    std::ifstream stream =
-        binary ? std::ifstream(file, std::ios::binary) : std::ifstream(file);
+    std::ios::openmode mode = binary ? std::ios::binary : std::ios::openmode();
 
+    std::ifstream stream = std::ifstream(file, mode);
     return std::string(std::istreambuf_iterator<char>(stream), {});
 }
 

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -103,18 +103,7 @@ TEST(FileTest, Read) {
     tmpfile.write("Hello");
     tmpfile.append(", world!");
 
-    auto stream = tmpfile.read();
-
-    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-    ASSERT_EQ(content, "Hello, world!");
-}
-
-TEST(FileTest, Slurp) {
-    const auto tmpfile = file(PREFIX);
-    tmpfile.write("Hello");
-    tmpfile.append(", world!");
-
-    auto content = tmpfile.slurp();
+    auto content = tmpfile.read();
     ASSERT_EQ(content, "Hello, world!");
 }
 
@@ -144,7 +133,7 @@ TEST(FileTest, Copy) {
         tmpfile.write("Hello, world!");
 
         const auto tmpcopy = file::copy(tmpfile, PREFIX);
-        ASSERT_EQ(tmpcopy.slurp(), "Hello, world!");
+        ASSERT_EQ(tmpcopy.read(), "Hello, world!");
         EXPECT_NE(fs::path(tmpfile), fs::path(tmpcopy));
     }
     {


### PR DESCRIPTION
- Remove `file::read` method
- Rename `file::slurp` method to `file::read`