### PR TITLE
Use new runners

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -15,20 +15,15 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - ubuntu-22.04
-          - macos-11
+          - ubuntu-24.04
           - macos-12
-          - macos-13
+          - macos-14
           - windows-2019
           - windows-2022
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Select Xcode 15.0 (for macOS 13)
-        run:  sudo xcode-select -s "/Applications/Xcode_15.0.app"
-        if:   matrix.os == 'macos-13'
 
       - name: Configure CMake
         run:  cmake -B ${{ env.build_dir }}


### PR DESCRIPTION
- Remove deprecated `macos@11`
- Use the new `macos@14`
- Replace `ubuntu@22.04` with `ubuntu@24.04`