### PR TITLE
Deprecate path::operator->

### DIFF
--- a/include/tmp/path
+++ b/include/tmp/path
@@ -21,7 +21,7 @@ public:
 
     /// Dereferences the managed path
     /// @returns A pointer to the path owned by *this
-    const std::filesystem::path* operator->() const noexcept;
+    [[deprecated]] const std::filesystem::path* operator->() const noexcept;
 
     /// Releases the ownership of the managed path;
     /// the destructor will not delete the managed path after the call

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -38,7 +38,7 @@ void create_parent(const fs::path& path) {
 /// Deletes the given path recursively, ignoring any errors
 /// @param path The path to remove recursively
 void remove(const path& path) noexcept {
-    if (!path->empty()) {
+    if (!static_cast<const fs::path&>(path).empty()) {
         std::error_code ec;
         fs::remove_all(path, ec);
     }

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 /// Tests directory creation with prefix
 TEST(directory, create_with_prefix) {
     directory tmpdir = directory(PREFIX);
-    fs::path parent = tmpdir->parent_path();
+    fs::path parent = tmpdir.path().parent_path();
 
     EXPECT_TRUE(fs::exists(tmpdir));
     EXPECT_TRUE(fs::is_directory(tmpdir));
@@ -20,7 +20,7 @@ TEST(directory, create_with_prefix) {
 /// Tests directory creation without prefix
 TEST(directory, create_without_prefix) {
     directory tmpdir = directory();
-    fs::path parent = tmpdir->parent_path();
+    fs::path parent = tmpdir.path().parent_path();
 
     EXPECT_TRUE(fs::exists(tmpdir));
     EXPECT_TRUE(fs::is_directory(tmpdir));
@@ -82,7 +82,7 @@ TEST(directory, move_constructor) {
     directory fst = directory(PREFIX);
     directory snd = std::move(fst);
 
-    EXPECT_TRUE(fst->empty());
+    EXPECT_TRUE(fst.path().empty());
     EXPECT_TRUE(fs::exists(snd));
 }
 

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 /// Tests file creation with prefix
 TEST(file, create_with_prefix) {
     file tmpfile = file(PREFIX);
-    fs::path parent = tmpfile->parent_path();
+    fs::path parent = tmpfile.path().parent_path();
 
     EXPECT_TRUE(fs::exists(tmpfile));
     EXPECT_TRUE(fs::is_regular_file(tmpfile));
@@ -20,7 +20,7 @@ TEST(file, create_with_prefix) {
 /// Tests file creation without prefix
 TEST(file, create_without_prefix) {
     file tmpfile = file();
-    fs::path parent = tmpfile->parent_path();
+    fs::path parent = tmpfile.path().parent_path();
 
     EXPECT_TRUE(fs::exists(tmpfile));
     EXPECT_TRUE(fs::is_regular_file(tmpfile));
@@ -33,7 +33,7 @@ TEST(file, create_with_suffix) {
 
     EXPECT_TRUE(fs::exists(tmpfile));
     EXPECT_TRUE(fs::is_regular_file(tmpfile));
-    EXPECT_EQ(tmpfile->extension(), ".test");
+    EXPECT_EQ(tmpfile.path().extension(), ".test");
 }
 
 /// Tests multiple file creation with the same prefix


### PR DESCRIPTION
- Mark `path::operator->` as deprecated
- Remove its usages