### PR TITLE
Close file descriptors of created files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,6 @@ Checks: >
   portability-*,
   readability-*,
   -bugprone-easily-swappable-parameters,
-  -cppcoreguidelines-pro-type-vararg,
   -misc-const-correctness,
   -misc-include-cleaner,
   -modernize-return-braced-init-list,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   portability-*,
   readability-*,
   -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-pro-type-vararg,
   -misc-const-correctness,
   -misc-include-cleaner,
   -modernize-return-braced-init-list,

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -129,8 +129,5 @@ private:
     /// @param binary   Whether the managed file is opened in binary write mode
     file(std::pair<std::filesystem::path, native_handle_type> handle,
          bool binary) noexcept;
-
-    /// Closes the implementation-defined handle
-    void close();
 };
 }    // namespace tmp

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -7,10 +7,6 @@
 #include <string>
 #include <string_view>
 
-#ifdef WIN32
-#include <windows.h>
-#endif
-
 namespace tmp {
 
 /// tmp::file is a smart handle that owns and manages a temporary file and
@@ -46,11 +42,12 @@ namespace tmp {
 class file final : public path {
 public:
     /// Implementation-defined handle type
-    using native_handle_type =
-#ifdef WIN32
-        HANDLE;
+#if defined(WIN32)
+    using native_handle_type = void*;    // HANDLE
+#elif __has_include(<unistd.h>)
+    using native_handle_type = int;    // POSIX file descriptor
 #else
-        int;
+#error "Provide a native file handle!"
 #endif
 
     /// Creates a unique temporary binary file

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -138,5 +138,8 @@ private:
     /// @param binary   Whether the managed file is opened in binary write mode
     file(std::pair<std::filesystem::path, native_handle_type> handle,
          bool binary) noexcept;
+
+    /// Closes the implementation-defined handle
+    void close();
 };
 }    // namespace tmp

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -7,6 +7,10 @@
 #include <string>
 #include <string_view>
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 namespace tmp {
 
 /// tmp::file is a smart handle that owns and manages a temporary file and
@@ -41,6 +45,14 @@ namespace tmp {
 /// @endcode
 class file final : public path {
 public:
+    /// Implementation-defined handle type
+    using native_handle_type =
+#ifdef WIN32
+        HANDLE;
+#else
+        int;
+#endif
+
     /// Creates a unique temporary binary file
     ///
     /// The file path consists of the system's temporary directory path, the
@@ -73,6 +85,10 @@ public:
                      std::string_view prefix = "",
                      std::string_view suffix = "");
 
+    /// Returns an implementation-defined handle of this file
+    /// @returns An implementation-defined handle of this file
+    [[nodiscard]] native_handle_type native_handle() const noexcept;
+
     /// Returns a path to this file
     /// @returns The full path to this file
     [[nodiscard]] const std::filesystem::path& path() const noexcept;
@@ -98,6 +114,9 @@ public:
     auto operator=(const file&) = delete;    ///< not copy-assignable
 
 private:
+    /// Implementation-defined handle to the file
+    native_handle_type handle;
+
     /// Whether the managed file is opened in binary write mode
     bool binary;
 
@@ -111,5 +130,13 @@ private:
     /// @param binary   Whether the managed file is opened in binary write mode
     /// @throws fs::filesystem_error if cannot create a file
     file(std::string_view prefix, std::string_view suffix, bool binary);
+
+    /// Creates a unique temporary file
+    ///
+    /// @param handle   A path to the created temporary file and its
+    ///                 implementation-defined handle
+    /// @param binary   Whether the managed file is opened in binary write mode
+    file(std::pair<std::filesystem::path, native_handle_type> handle,
+         bool binary) noexcept;
 };
 }    // namespace tmp

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -41,7 +41,7 @@ namespace tmp {
 /// @endcode
 class file final : public path {
 public:
-    /// Implementation-defined handle type
+    /// Implementation-defined handle type to the temporary file
 #if defined(WIN32)
     using native_handle_type = void*;    // HANDLE
 #elif __has_include(<unistd.h>)
@@ -50,20 +50,16 @@ public:
 #error "Provide a native file handle!"
 #endif
 
-    /// Creates a unique temporary binary file
-    ///
-    /// The file path consists of the system's temporary directory path, the
-    /// given prefix, suffix, and random characters to ensure path uniqueness
+    /// Creates a unique temporary file and opens it for reading and writing
+    /// in binary mode
     ///
     /// @param prefix   A prefix to be used in the temporary file path
     /// @param suffix   A suffix to be used in the temporary file path
     /// @throws std::filesystem::filesystem_error if cannot create a file
     explicit file(std::string_view prefix = "", std::string_view suffix = "");
 
-    /// Creates a unique temporary text file
-    ///
-    /// The file path consists of the system's temporary directory path, the
-    /// given prefix, suffix, and random characters to ensure path uniqueness
+    /// Creates a unique temporary file and opens it for reading and writing
+    /// in text mode
     ///
     /// @param prefix   A prefix to be used in the temporary file path
     /// @param suffix   A suffix to be used in the temporary file path
@@ -82,8 +78,8 @@ public:
                      std::string_view prefix = "",
                      std::string_view suffix = "");
 
-    /// Returns an implementation-defined handle of this file
-    /// @returns An implementation-defined handle of this file
+    /// Returns an implementation-defined handle to this file
+    /// @returns The underlying implementation-defined handle
     [[nodiscard]] native_handle_type native_handle() const noexcept;
 
     /// Returns a path to this file

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -113,10 +113,8 @@ private:
     /// Whether the managed file is opened in binary write mode
     bool binary;
 
-    /// Creates a unique temporary file
-    ///
-    /// The file path consists of the system's temporary directory path, the
-    /// given prefix, suffix, and random characters to ensure path uniqueness
+    /// Creates a unique temporary file and opens it for reading and writing
+    /// in the specified mode
     ///
     /// @param prefix   A prefix to be used in the temporary file path
     /// @param suffix   A suffix to be used in the temporary file path

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -24,7 +24,7 @@ public:
     [[deprecated]] const std::filesystem::path* operator->() const noexcept;
 
     /// Releases the ownership of the managed path;
-    /// the destructor will not delete or close the managed path after the call
+    /// the destructor will not delete the managed path after the call
     /// @returns The managed path
     std::filesystem::path release() noexcept;
 

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -47,7 +47,7 @@ protected:
     /// @param path A path to manage
     explicit path(std::filesystem::path path);
 
-    path(path&&) noexcept;                   ///< move-constructible
-    path& operator=(path&&) noexcept;        ///< move-assignable
+    path(path&&) noexcept;               ///< move-constructible
+    path& operator=(path&&) noexcept;    ///< move-assignable
 };
 }    // namespace tmp

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -39,8 +39,6 @@ public:
     /// Deletes the managed path recursively if it is not empty
     virtual ~path() noexcept;
 
-    path(path&&) noexcept;                   ///< move-constructible
-    path& operator=(path&&) noexcept;        ///< move-assignable
     path(const path&) = delete;              ///< not copy-constructible
     auto operator=(const path&) = delete;    ///< not copy-assignable
 
@@ -48,5 +46,8 @@ protected:
     /// Constructs a tmp::path which owns @p path
     /// @param path A path to manage
     explicit path(std::filesystem::path path);
+
+    path(path&&) noexcept;                   ///< move-constructible
+    path& operator=(path&&) noexcept;        ///< move-assignable
 };
 }    // namespace tmp

--- a/include/tmp/path
+++ b/include/tmp/path
@@ -24,7 +24,7 @@ public:
     [[deprecated]] const std::filesystem::path* operator->() const noexcept;
 
     /// Releases the ownership of the managed path;
-    /// the destructor will not delete the managed path after the call
+    /// the destructor will not delete or close the managed path after the call
     /// @returns The managed path
     std::filesystem::path release() noexcept;
 

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -93,10 +93,16 @@ fs::path create_file(std::string_view prefix, std::string_view suffix) {
 
         ec = std::error_code(err, std::system_category());
     }
+
+    CloseHandle(file);
 #else
-    if (mkstemps(path.data(), static_cast<int>(suffix.size())) == -1) {
+    const int fileDescriptor =
+        mkstemps(path.data(), static_cast<int>(suffix.size()));
+    if (fileDescriptor == -1) {
         ec = std::error_code(errno, std::system_category());
     }
+
+    close(fileDescriptor);
 #endif
     if (ec) {
         throw fs::filesystem_error("Cannot create temporary file", ec);

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -24,6 +24,14 @@ namespace {
 
 namespace fs = std::filesystem;
 
+// Confirm that native_handle_type matches `TriviallyCopyable` named requirement
+static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
+
+#ifdef WIN32
+// Confirm that `HANDLE` is `void*` as implemented in `file`
+static_assert(std::is_same_v<HANDLE, void*>);
+#endif
+
 /// Options for recursive overwriting copying
 constexpr fs::copy_options copy_options =
     fs::copy_options::recursive | fs::copy_options::overwrite_existing;
@@ -179,7 +187,7 @@ void close(const file& file) noexcept {
 #ifdef WIN32
         CloseHandle(file.native_handle());
 #else
-        ::close(file.native_handle());
+        close(file.native_handle());
 #endif
     }
 }

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -254,10 +254,6 @@ void path::move(const fs::path& to) {
         throw_move_error(to, ec);
     }
 
-    if (file* file = dynamic_cast<class file*>(this)) {
-        close(*file);
-    }
-
     remove(*this);
     release();
 }
@@ -329,8 +325,8 @@ file& file::operator=(file&& other) noexcept {
 
     tmp::path::operator=(std::move(other));
 
-    this->binary = other.binary; // NOLINT(bugprone-use-after-move)
-    this->handle = other.handle; // NOLINT(bugprone-use-after-move)
+    this->binary = other.binary;    // NOLINT(bugprone-use-after-move)
+    this->handle = other.handle;    // NOLINT(bugprone-use-after-move)
 
     return *this;
 };

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -325,15 +325,15 @@ file::~file() noexcept {
 file::file(file&&) noexcept = default;
 
 file& file::operator=(file&& other) noexcept {
-    tmp::path::operator=(std::move(other));
-
     close(*this);
 
-    this->binary = other.binary;
-    this->handle = other.handle;
+    tmp::path::operator=(std::move(other));
+
+    this->binary = other.binary; // NOLINT(bugprone-use-after-move)
+    this->handle = other.handle; // NOLINT(bugprone-use-after-move)
 
     return *this;
-}
+};
 
 //===----------------------------------------------------------------------===//
 // tmp::directory implementation

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -321,9 +321,10 @@ file::~file() noexcept {
 file::file(file&&) noexcept = default;
 
 file& file::operator=(file&& other) noexcept {
-    close(*this);
 
     tmp::path::operator=(std::move(other));
+
+    close(*this);
 
     this->binary = other.binary;    // NOLINT(bugprone-use-after-move)
     this->handle = other.handle;    // NOLINT(bugprone-use-after-move)

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -257,10 +257,6 @@ void path::move(const fs::path& to) {
         throw_move_error(to, ec);
     }
 
-    if (file* file = dynamic_cast<class file*>(this)) {
-        close(*file);
-    }
-
     remove(*this);
     release();
 }

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -223,10 +223,6 @@ const fs::path* path::operator->() const noexcept {
 }
 
 fs::path path::release() noexcept {
-    if (file* file = dynamic_cast<class file*>(this)) {
-        close(*file);
-    }
-
     fs::path path = std::move(underlying);
     underlying.clear();
 
@@ -253,6 +249,10 @@ void path::move(const fs::path& to) {
 
     if (ec) {
         throw_move_error(to, ec);
+    }
+
+    if (file* file = dynamic_cast<class file*>(this)) {
+        close(*file);
     }
 
     remove(*this);
@@ -322,7 +322,6 @@ file::~file() noexcept {
 file::file(file&&) noexcept = default;
 
 file& file::operator=(file&& other) noexcept {
-
     tmp::path::operator=(std::move(other));
 
     close(*this);
@@ -331,7 +330,7 @@ file& file::operator=(file&& other) noexcept {
     this->handle = other.handle;    // NOLINT(bugprone-use-after-move)
 
     return *this;
-};
+}
 
 //===----------------------------------------------------------------------===//
 // tmp::directory implementation

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -184,9 +184,9 @@ void remove(const fs::path& path) noexcept {
 /// @param file     The file to close
 void close(const file& file) noexcept {
 #ifdef WIN32
-        CloseHandle(file.native_handle());
+    CloseHandle(file.native_handle());
 #else
-        ::close(file.native_handle());
+    ::close(file.native_handle());
 #endif
 }
 

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -183,13 +183,11 @@ void remove(const fs::path& path) noexcept {
 /// Closes the given file, ignoring any errors
 /// @param file     The file to close
 void close(const file& file) noexcept {
-    if (!file.path().empty()) {
 #ifdef WIN32
         CloseHandle(file.native_handle());
 #else
         ::close(file.native_handle());
 #endif
-    }
 }
 
 /// Throws a filesystem error indicating that a temporary resource cannot be

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -222,8 +222,13 @@ const fs::path* path::operator->() const noexcept {
 }
 
 fs::path path::release() noexcept {
+    if (file* file = dynamic_cast<class file*>(this)) {
+        close(*file);
+    }
+
     fs::path path = std::move(underlying);
     underlying.clear();
+
     return path;
 }
 
@@ -247,6 +252,10 @@ void path::move(const fs::path& to) {
 
     if (ec) {
         throw_move_error(to, ec);
+    }
+
+    if (file* file = dynamic_cast<class file*>(this)) {
+        close(*file);
     }
 
     remove(*this);
@@ -287,7 +296,7 @@ file file::copy(const fs::path& path, std::string_view prefix,
 }
 
 file::native_handle_type file::native_handle() const noexcept {
-    return this->handle;
+    return handle;
 }
 
 const fs::path& file::path() const noexcept {

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -187,7 +187,7 @@ void close(const file& file) noexcept {
 #ifdef WIN32
         CloseHandle(file.native_handle());
 #else
-        close(file.native_handle());
+        ::close(file.native_handle());
 #endif
     }
 }

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -323,7 +323,7 @@ file& file::operator=(file&& other) noexcept {
     this->handle = other.handle;
 
     return *this;
-};
+}
 
 //===----------------------------------------------------------------------===//
 // tmp::directory implementation

--- a/src/tmp.cpp
+++ b/src/tmp.cpp
@@ -92,17 +92,19 @@ fs::path create_file(std::string_view prefix, std::string_view suffix) {
         }
 
         ec = std::error_code(err, std::system_category());
+    } else {
+        CloseHandle(file);
     }
 
-    CloseHandle(file);
 #else
     const int fileDescriptor =
         mkstemps(path.data(), static_cast<int>(suffix.size()));
     if (fileDescriptor == -1) {
         ec = std::error_code(errno, std::system_category());
+    } else {
+        close(fileDescriptor);
     }
 
-    close(fileDescriptor);
 #endif
     if (ec) {
         throw fs::filesystem_error("Cannot create temporary file", ec);

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -277,7 +277,7 @@ TEST(file, release) {
     }
 
     EXPECT_TRUE(fs::exists(path));
-    EXPECT_FALSE(native_handle_is_valid(handle));
+    EXPECT_TRUE(native_handle_is_valid(handle));
 
     fs::remove(path);
 }

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -39,16 +39,6 @@ bool native_handle_is_valid(file::native_handle_type handle) {
 }
 }    // namespace
 
-/// Tests requirements for native_handle_type
-TEST(file, native_handle_type) {
-    // `TriviallyCopyable` named requirement
-    static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
-#ifdef WIN32
-    // Confirm that `HANDLE` is `void*` as implemented in `file`
-    static_assert(std::is_same_v<HANDLE, void*>);
-#endif
-}
-
 /// Tests file creation with prefix
 TEST(file, create_with_prefix) {
     file tmpfile = file(PREFIX);

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -64,7 +64,7 @@ TEST(file, native_handle_type) {
     static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
 #ifdef WIN32
     // Confirm that `HANDLE` is `void*` as implemented in `file`
-    static_assert(std::same_as<HANDLE, void*>);
+    static_assert(std::is_same_v<HANDLE, void*>);
 #endif
 }
 

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -59,6 +59,11 @@ TEST(file, create_with_prefix) {
     EXPECT_FALSE(native_handle_is_valid(handle));
 }
 
+TEST(file, native_handle_type) {
+    // `TriviallyCopyable` named requirement
+    static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
+}
+
 /// Tests file creation without prefix
 TEST(file, create_without_prefix) {
     file tmpfile = file();

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -41,21 +41,12 @@ bool native_handle_is_valid(file::native_handle_type handle) {
 
 /// Tests file creation with prefix
 TEST(file, create_with_prefix) {
-    file::native_handle_type handle{};
+    file tmpfile = file(PREFIX);
+    fs::path parent = tmpfile.path().parent_path();
 
-    {
-        file tmpfile = file(PREFIX);
-        fs::path parent = tmpfile.path().parent_path();
-
-        EXPECT_TRUE(fs::exists(tmpfile));
-        EXPECT_TRUE(fs::is_regular_file(tmpfile));
-        EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path() / PREFIX));
-
-        handle = tmpfile.native_handle();
-        EXPECT_TRUE(native_handle_is_valid(handle));
-    }
-
-    EXPECT_FALSE(native_handle_is_valid(handle));
+    EXPECT_TRUE(fs::exists(tmpfile));
+    EXPECT_TRUE(fs::is_regular_file(tmpfile));
+    EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path() / PREFIX));
 }
 
 TEST(file, native_handle_type) {

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -39,6 +39,16 @@ bool native_handle_is_valid(file::native_handle_type handle) {
 }
 }    // namespace
 
+/// Tests requirements for native_handle_type
+TEST(file, native_handle_type) {
+    // `TriviallyCopyable` named requirement
+    static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
+#ifdef WIN32
+    // Confirm that `HANDLE` is `void*` as implemented in `file`
+    static_assert(std::is_same_v<HANDLE, void*>);
+#endif
+}
+
 /// Tests file creation with prefix
 TEST(file, create_with_prefix) {
     file tmpfile = file(PREFIX);
@@ -47,15 +57,7 @@ TEST(file, create_with_prefix) {
     EXPECT_TRUE(fs::exists(tmpfile));
     EXPECT_TRUE(fs::is_regular_file(tmpfile));
     EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path() / PREFIX));
-}
-
-TEST(file, native_handle_type) {
-    // `TriviallyCopyable` named requirement
-    static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
-#ifdef WIN32
-    // Confirm that `HANDLE` is `void*` as implemented in `file`
-    static_assert(std::is_same_v<HANDLE, void*>);
-#endif
+    EXPECT_TRUE(native_handle_is_valid(tmpfile.native_handle()));
 }
 
 /// Tests file creation without prefix
@@ -66,6 +68,7 @@ TEST(file, create_without_prefix) {
     EXPECT_TRUE(fs::exists(tmpfile));
     EXPECT_TRUE(fs::is_regular_file(tmpfile));
     EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
+    EXPECT_TRUE(native_handle_is_valid(tmpfile.native_handle()));
 }
 
 /// Tests file creation with suffix
@@ -75,6 +78,7 @@ TEST(file, create_with_suffix) {
     EXPECT_TRUE(fs::exists(tmpfile));
     EXPECT_TRUE(fs::is_regular_file(tmpfile));
     EXPECT_EQ(tmpfile.path().extension(), ".test");
+    EXPECT_TRUE(native_handle_is_valid(tmpfile.native_handle()));
 }
 
 /// Tests multiple file creation with the same prefix

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -267,7 +267,7 @@ TEST(file, release) {
     }
 
     EXPECT_TRUE(fs::exists(path));
-    EXPECT_TRUE(native_handle_is_valid(handle));
+    EXPECT_FALSE(native_handle_is_valid(handle));
 
     fs::remove(path);
 }

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -242,6 +242,7 @@ TEST(file, move_constructor) {
 
     EXPECT_TRUE(fst.path().empty());
     EXPECT_TRUE(fs::exists(snd));
+    EXPECT_TRUE(native_handle_is_valid(snd.native_handle()));
 }
 
 /// Tests file move assignment operator

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -62,6 +62,10 @@ TEST(file, create_with_prefix) {
 TEST(file, native_handle_type) {
     // `TriviallyCopyable` named requirement
     static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
+#ifdef WIN32
+    // Confirm that `HANDLE` is `void*` as implemented in `file`
+    static_assert(std::same_as<HANDLE, void*>);
+#endif
 }
 
 /// Tests file creation without prefix


### PR DESCRIPTION
- Add `native_handle_type` to temporary files
- Add `file::native_handle` method
- Save the native handle
- Close the file on destruction, releasing or moving