### PR TITLE
Validate labels and extensions for temporary entries

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -43,6 +43,7 @@ public:
   ///
   /// @param label   A label to attach to the temporary directory path
   /// @throws std::filesystem::filesystem_error if cannot create a directory
+  /// @throws std::invalid_argument             if the label is ill-formatted
   explicit directory(std::string_view label = "");
 
   /// Creates a unique temporary copy recursively from the given path
@@ -51,6 +52,7 @@ public:
   /// @param label  A label to attach to the temporary directory path
   /// @returns The new temporary directory
   /// @throws std::filesystem::filesystem_error if @p path is not a directory
+  /// @throws std::invalid_argument             if the label is ill-formatted
   static directory copy(const std::filesystem::path& path,
                         std::string_view label = "");
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -56,6 +56,7 @@ public:
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path
   /// @throws std::filesystem::filesystem_error if cannot create a file
+  /// @throws std::invalid_argument             if arguments are ill-formatted
   explicit file(std::string_view label = "", std::string_view extension = "");
 
   /// Creates a unique temporary file and opens it for reading and writing
@@ -64,6 +65,7 @@ public:
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path
   /// @throws std::filesystem::filesystem_error if cannot create a file
+  /// @throws std::invalid_argument             if arguments are ill-formatted
   static file text(std::string_view label = "",
                    std::string_view extension = "");
 
@@ -73,7 +75,8 @@ public:
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path
   /// @returns The new temporary file
-  /// @throws std::filesystem::filesystem_error if @p path is not a file
+  /// @throws std::filesystem::filesystem_error if path is not a file
+  /// @throws std::invalid_argument             if arguments are ill-formatted
   static file copy(const std::filesystem::path& path,
                    std::string_view label = "",
                    std::string_view extension = "");
@@ -115,7 +118,8 @@ private:
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path
   /// @param binary    Whether the managed file is opened in binary write mode
-  /// @throws fs::filesystem_error if cannot create a file
+  /// @throws std::filesystem::filesystem_error if cannot create a file
+  /// @throws std::invalid_argument             if arguments are ill-formatted
   file(std::string_view label, std::string_view extension, bool binary);
 
   /// Creates a unique temporary file

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -20,7 +20,8 @@ namespace {
 /// temporary directory, and returns its path
 /// @param label    A label to attach to the temporary directory path
 /// @returns A path to the created temporary directory
-/// @throws fs::filesystem_error if cannot create the temporary directory
+/// @throws fs::filesystem_error  if cannot create a temporary directory
+/// @throws std::invalid_argument if the label is ill-formatted
 fs::path create_directory(std::string_view label) {
   fs::path::string_type path = make_pattern(label, "");
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -35,7 +35,8 @@ static_assert(std::is_same_v<HANDLE, void*>);
 /// @param label     A label to attach to the temporary file path
 /// @param extension An extension of the temporary file path
 /// @returns A path to the created temporary file and a handle to it
-/// @throws fs::filesystem_error if cannot create the temporary file
+/// @throws fs::filesystem_error  if cannot create a temporary file
+/// @throws std::invalid_argument if the label or extension is ill-formatted
 std::pair<fs::path, file::native_handle_type>
 create_file(std::string_view label, std::string_view extension) {
   fs::path::string_type path = make_pattern(label, extension);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,7 +24,9 @@ void validate_label(const fs::path& label) {
   if (++label.begin() != label.end() || label.is_absolute() ||
       label.has_root_path() || label.filename() == "." ||
       label.filename() == "..") {
-    throw std::invalid_argument("");
+    throw std::invalid_argument(
+        "Cannot create a temporary entry: label must be empty or a valid "
+        "single-segmented relative pathname");
   }
 }
 
@@ -38,7 +40,9 @@ void validate_extension(std::string_view extension) {
 
   fs::path path = extension;
   if (++path.begin() != path.end()) {
-    throw std::invalid_argument("");
+    throw std::invalid_argument(
+        "Cannot create a temporary file: extension must be empty or a valid "
+        "single-segmented pathname");
   }
 }
 }    // namespace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -11,11 +11,38 @@
 
 namespace tmp {
 
+namespace {
+void validate_label(const fs::path& label) {
+  if (label.empty()) {
+    return;
+  }
+
+  if (++label.begin() != label.end() || label.is_absolute() ||
+      label.has_root_path() || label.filename() == "." ||
+      label.filename() == "..") {
+    throw std::logic_error("");
+  }
+}
+
+void validate_extension(std::string_view extension) {
+  if (extension.empty()) {
+    return;
+  }
+
+  if (extension.find(fs::path::preferred_separator) != std::string_view::npos) {
+    throw std::logic_error("");
+  }
+}
+}    // namespace
+
 bool create_parent(const fs::path& path, std::error_code& ec) {
   return fs::create_directories(path.parent_path(), ec);
 }
 
 fs::path make_pattern(std::string_view label, std::string_view extension) {
+  validate_label(label);
+  validate_extension(extension);
+
 #ifdef _WIN32
   constexpr static std::size_t CHARS_IN_GUID = 39;
   GUID guid;
@@ -32,8 +59,8 @@ fs::path make_pattern(std::string_view label, std::string_view extension) {
 #endif
 
   fs::path pattern = fs::temp_directory_path() / label / name;
-
   pattern += extension;
+
   return pattern;
 }
 }    // namespace tmp

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,6 +12,10 @@
 namespace tmp {
 
 namespace {
+
+/// Checks that the given label is valid to attach to a temporary entry path
+/// @param label The label to check validity for
+/// @throws std::invalid_argument if the label cannot be attached to a path
 void validate_label(const fs::path& label) {
   if (label.empty()) {
     return;
@@ -20,10 +24,13 @@ void validate_label(const fs::path& label) {
   if (++label.begin() != label.end() || label.is_absolute() ||
       label.has_root_path() || label.filename() == "." ||
       label.filename() == "..") {
-    throw std::logic_error("");
+    throw std::invalid_argument("");
   }
 }
 
+/// Checks that the given extension is valid to be an extension of a file path
+/// @param extension The extension to check validity for
+/// @throws std::invalid_argument if the extension cannot be used in a file path
 void validate_extension(std::string_view extension) {
   if (extension.empty()) {
     return;
@@ -31,7 +38,7 @@ void validate_extension(std::string_view extension) {
 
   fs::path path = extension;
   if (++path.begin() != path.end()) {
-    throw std::logic_error("");
+    throw std::invalid_argument("");
   }
 }
 }    // namespace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -29,7 +29,8 @@ void validate_extension(std::string_view extension) {
     return;
   }
 
-  if (extension.find(fs::path::preferred_separator) != std::string_view::npos) {
+  fs::path path = extension;
+  if (++path.begin() != path.end()) {
     throw std::logic_error("");
   }
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -23,6 +23,7 @@ bool create_parent(const fs::path& path, std::error_code& ec);
 /// @param label     A label to attach to the path pattern
 /// @param extension An extension of the temporary file path
 /// @returns A path pattern for the unique temporary path
-/// @throws std::bad_alloc if memory allocation fails
+/// @throws std::invalid_argument if the label or extension is ill-formatted
+/// @throws std::bad_alloc        if memory allocation fails
 fs::path make_pattern(std::string_view label, std::string_view extension);
 }    // namespace tmp

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -51,15 +51,15 @@ TEST(directory, create_multiple) {
 
 /// Tests error handling with invalid labels
 TEST(directory, create_invalid_label) {
-  EXPECT_THROW(directory("multi/segment"), std::logic_error);
-  EXPECT_THROW(directory("/root"), std::logic_error);
-  EXPECT_THROW(directory(".."), std::logic_error);
-  EXPECT_THROW(directory("."), std::logic_error);
+  EXPECT_THROW(directory("multi/segment"), std::invalid_argument);
+  EXPECT_THROW(directory("/root"), std::invalid_argument);
+  EXPECT_THROW(directory(".."), std::invalid_argument);
+  EXPECT_THROW(directory("."), std::invalid_argument);
 
   fs::path root = fs::temp_directory_path().root_name();
   if (!root.empty()) {
-    EXPECT_THROW(directory(root.string() + "relative"), std::logic_error);
-    EXPECT_THROW(directory(root.string() + "/root"), std::logic_error);
+    EXPECT_THROW(directory(root.string() + "relative"), std::invalid_argument);
+    EXPECT_THROW(directory(root.string() + "/root"), std::invalid_argument);
   }
 }
 

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -49,6 +49,19 @@ TEST(directory, create_multiple) {
   EXPECT_FALSE(fs::equivalent(fst, snd));
 }
 
+/// Tests error handling with invalid labels
+TEST(directory, create_invalid_label) {
+  EXPECT_THROW(directory("multi/segment"), std::logic_error);
+  EXPECT_THROW(directory("/root"), std::logic_error);
+  EXPECT_THROW(directory(".."), std::logic_error);
+
+  fs::path root = fs::temp_directory_path().root_name();
+  if (!root.empty()) {
+    EXPECT_THROW(directory(root.string() + "relative"), std::logic_error);
+    EXPECT_THROW(directory(root.string() + "/root"), std::logic_error);
+  }
+}
+
 /// Tests creation of a temporary copy of a directory
 TEST(directory, copy_directory) {
   directory tmpdir = directory();

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -54,6 +54,7 @@ TEST(directory, create_invalid_label) {
   EXPECT_THROW(directory("multi/segment"), std::logic_error);
   EXPECT_THROW(directory("/root"), std::logic_error);
   EXPECT_THROW(directory(".."), std::logic_error);
+  EXPECT_THROW(directory("."), std::logic_error);
 
   fs::path root = fs::temp_directory_path().root_name();
   if (!root.empty()) {

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -89,12 +89,21 @@ TEST(file, create_invalid_label) {
   EXPECT_THROW(file("multi/segment"), std::logic_error);
   EXPECT_THROW(file("/root"), std::logic_error);
   EXPECT_THROW(file(".."), std::logic_error);
+  EXPECT_THROW(file("."), std::logic_error);
 
   fs::path root = fs::temp_directory_path().root_name();
   if (!root.empty()) {
     EXPECT_THROW(file(root.string() + "relative"), std::logic_error);
     EXPECT_THROW(file(root.string() + "/root"), std::logic_error);
   }
+}
+
+/// Tests error handling with invalid extensions
+TEST(file, create_invalid_extension) {
+  EXPECT_THROW(file("", "multi/segment"), std::logic_error);
+  EXPECT_THROW(file("", "/root"), std::logic_error);
+  EXPECT_THROW(file("", "/.."), std::logic_error);
+  EXPECT_THROW(file("", "/."), std::logic_error);
 }
 
 /// Tests creation of a temporary copy of a file

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -86,24 +86,24 @@ TEST(file, create_multiple) {
 
 /// Tests error handling with invalid labels
 TEST(file, create_invalid_label) {
-  EXPECT_THROW(file("multi/segment"), std::logic_error);
-  EXPECT_THROW(file("/root"), std::logic_error);
-  EXPECT_THROW(file(".."), std::logic_error);
-  EXPECT_THROW(file("."), std::logic_error);
+  EXPECT_THROW(file("multi/segment"), std::invalid_argument);
+  EXPECT_THROW(file("/root"), std::invalid_argument);
+  EXPECT_THROW(file(".."), std::invalid_argument);
+  EXPECT_THROW(file("."), std::invalid_argument);
 
   fs::path root = fs::temp_directory_path().root_name();
   if (!root.empty()) {
-    EXPECT_THROW(file(root.string() + "relative"), std::logic_error);
-    EXPECT_THROW(file(root.string() + "/root"), std::logic_error);
+    EXPECT_THROW(file(root.string() + "relative"), std::invalid_argument);
+    EXPECT_THROW(file(root.string() + "/root"), std::invalid_argument);
   }
 }
 
 /// Tests error handling with invalid extensions
 TEST(file, create_invalid_extension) {
-  EXPECT_THROW(file("", "multi/segment"), std::logic_error);
-  EXPECT_THROW(file("", "/root"), std::logic_error);
-  EXPECT_THROW(file("", "/.."), std::logic_error);
-  EXPECT_THROW(file("", "/."), std::logic_error);
+  EXPECT_THROW(file("", "multi/segment"), std::invalid_argument);
+  EXPECT_THROW(file("", "/root"), std::invalid_argument);
+  EXPECT_THROW(file("", "/.."), std::invalid_argument);
+  EXPECT_THROW(file("", "/."), std::invalid_argument);
 }
 
 /// Tests creation of a temporary copy of a file

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -84,6 +84,19 @@ TEST(file, create_multiple) {
   EXPECT_FALSE(fs::equivalent(fst, snd));
 }
 
+/// Tests error handling with invalid labels
+TEST(file, create_invalid_label) {
+  EXPECT_THROW(file("multi/segment"), std::logic_error);
+  EXPECT_THROW(file("/root"), std::logic_error);
+  EXPECT_THROW(file(".."), std::logic_error);
+
+  fs::path root = fs::temp_directory_path().root_name();
+  if (!root.empty()) {
+    EXPECT_THROW(file(root.string() + "relative"), std::logic_error);
+    EXPECT_THROW(file(root.string() + "/root"), std::logic_error);
+  }
+}
+
 /// Tests creation of a temporary copy of a file
 TEST(file, copy_file) {
   file tmpfile = file();


### PR DESCRIPTION
Constructors now throw `std::invalid_argument` when the `label` or `extension` arguments have invalid values