### PR TITLE
Do not export private methods

### DIFF
--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -54,7 +54,7 @@ private:
   /// Releases the ownership of the managed path
   /// @note the destructor will not delete the managed path after the call
   /// @returns The full path this entry manages
-  std::filesystem::path release() noexcept;
+  std::filesystem::path release() noexcept TMP_NO_EXPORT;
 };
 }    // namespace tmp
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -116,13 +116,14 @@ private:
   /// @param binary    Whether the managed file is opened in binary write mode
   /// @throws std::filesystem::filesystem_error if cannot create a file
   /// @throws std::invalid_argument             if arguments are ill-formatted
-  file(std::string_view label, std::string_view extension, bool binary);
+  file(std::string_view label, std::string_view extension,
+       bool binary) TMP_NO_EXPORT;
 
   /// Creates a unique temporary file
   /// @param handle    A path to the created temporary file and its handle
   /// @param binary    Whether the managed file is opened in binary write mode
   file(std::pair<std::filesystem::path, native_handle_type> handle,
-       bool binary) noexcept;
+       bool binary) noexcept TMP_NO_EXPORT;
 };
 }    // namespace tmp
 


### PR DESCRIPTION
Mark `tmp::entry::release` and private `tmp::file` constructors as `NO_EXPORT`