### PR TITLE
Open temporary directories

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -68,6 +68,12 @@ public:
   directory& operator=(directory&&) noexcept;    ///< move-assignable
   directory(const directory&) = delete;          ///< not copy-constructible
   auto operator=(const directory&) = delete;     ///< not copy-assignable
+
+private:
+  /// Creates a unique temporary directory
+  /// @param handle    A path to the created temporary directory and its handle
+  directory(std::pair<std::filesystem::path, native_handle_type>
+                handle) noexcept TMP_NO_EXPORT;
 };
 }    // namespace tmp
 

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -36,6 +36,10 @@ public:
   /// @returns The full path this entry manages
   const std::filesystem::path& path() const noexcept;
 
+  /// Returns an implementation-defined handle to this entry
+  /// @returns The underlying implementation-defined handle
+  native_handle_type native_handle() const noexcept;
+
   /// Moves the managed path recursively to a given target, releasing
   /// ownership of the managed path
   /// @note The target path parent is created when this function is called
@@ -43,7 +47,7 @@ public:
   /// @throws std::filesystem::filesystem_error if cannot move the owned path
   void move(const std::filesystem::path& to);
 
-  /// Deletes the managed path recursively
+  /// Deletes the managed path recursively and closes its handle
   virtual ~entry() noexcept;
 
   entry(const entry&) = delete;             ///< not copy-constructible
@@ -70,7 +74,8 @@ public:
 protected:
   /// Creates a temporary entry which owns the given path
   /// @param path      A path to manage
-  explicit entry(std::filesystem::path path);
+  /// @param handle    An implementation-defined handle to this entry
+  explicit entry(std::filesystem::path path, native_handle_type handle);
 
   entry(entry&&) noexcept;               ///< move-constructible
   entry& operator=(entry&&) noexcept;    ///< move-assignable
@@ -78,6 +83,9 @@ protected:
 private:
   /// The managed path
   std::filesystem::path pathobject;
+
+  /// Implementation-defined handle to this entry
+  native_handle_type handle;
 
   /// Releases the ownership of the managed path
   /// @note the destructor will not delete the managed path after the call

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -15,8 +15,8 @@ namespace tmp {
 /// - the managing tmp::entry object is destroyed
 /// - the managing tmp::entry object is assigned another path via operator=
 ///
-/// Subclasses should provide a path to manage for this class;
-/// any opening or closing operations should be managed by subclasses
+/// Subclasses must provide a path and an open handle to the entry constructor;
+/// entry closes the handle before deleting the managed path
 class TMP_EXPORT entry {
 public:
 /// Implementation-defined handle type to the temporary entry

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -19,6 +19,15 @@ namespace tmp {
 /// any opening or closing operations should be managed by subclasses
 class TMP_EXPORT entry {
 public:
+/// Implementation-defined handle type to the temporary entry
+#if defined(_WIN32)
+  using native_handle_type = void*;    // HANDLE
+#elif __has_include(<unistd.h>)
+  using native_handle_type = int;    // POSIX file descriptor
+#else
+#error "Target platform not supported"
+#endif
+
   /// Returns the managed path
   /// @returns The full path this entry manages
   operator const std::filesystem::path&() const noexcept;

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -73,10 +73,6 @@ public:
                    std::string_view label = "",
                    std::string_view extension = "");
 
-  /// Returns an implementation-defined handle to this file
-  /// @returns The underlying implementation-defined handle
-  native_handle_type native_handle() const noexcept;
-
   /// Reads the entire contents of this file
   /// @returns A string with this file contents
   std::string read() const;
@@ -98,7 +94,7 @@ public:
   /// @returns An opened stream for output operations
   std::ofstream output_stream(std::ios::openmode mode = std::ios::trunc) const;
 
-  /// Deletes (and closes) the managed file
+  /// Deletes the managed file
   ~file() noexcept override;
 
   file(file&&) noexcept;                   ///< move-constructible
@@ -107,9 +103,6 @@ public:
   auto operator=(const file&) = delete;    ///< not copy-assignable
 
 private:
-  /// Implementation-defined handle to the file
-  native_handle_type handle;
-
   /// Whether the managed file is opened in binary write mode
   bool binary;
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -45,15 +45,6 @@ namespace tmp {
 /// @endcode
 class TMP_EXPORT file final : public entry {
 public:
-  /// Implementation-defined handle type to the temporary file
-#if defined(_WIN32)
-  using native_handle_type = void*;    // HANDLE
-#elif __has_include(<unistd.h>)
-  using native_handle_type = int;    // POSIX file descriptor
-#else
-#error "Target platform not supported"
-#endif
-
   /// Creates a unique temporary file and opens it for reading and writing
   /// in binary mode
   /// @param label     A label to attach to the temporary file path

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -9,7 +9,9 @@
 #include <system_error>
 
 #ifdef _WIN32
+
 #include <Windows.h>
+
 #else
 #include <cerrno>
 #include <fcntl.h>
@@ -44,6 +46,11 @@ create_directory(std::string_view label) {
 
     ec = std::error_code(err, std::system_category());
   }
+
+  HANDLE handle =
+      CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 #else
   if (mkdtemp(path.data()) == nullptr) {
     ec = std::error_code(errno, std::system_category());
@@ -94,6 +101,7 @@ fs::directory_iterator directory::list() const {
 directory::~directory() noexcept = default;
 
 directory::directory(directory&&) noexcept = default;
+
 directory& directory::operator=(directory&&) noexcept = default;
 }    // namespace tmp
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -56,7 +56,7 @@ create_directory(std::string_view label) {
     ec = std::error_code(errno, std::system_category());
   }
 
-  int handle = open(path.data(), O_DIRECTORY);
+  int handle = open(path.data(), O_DIRECTORY);    // NOLINT(*-vararg)
 #endif
 
   if (ec) {

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -9,9 +9,7 @@
 #include <system_error>
 
 #ifdef _WIN32
-
 #include <Windows.h>
-
 #else
 #include <cerrno>
 #include <fcntl.h>
@@ -46,22 +44,24 @@ create_directory(std::string_view label) {
 
     ec = std::error_code(err, std::system_category());
   }
-
-  HANDLE handle =
-      CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE,
-                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 #else
   if (mkdtemp(path.data()) == nullptr) {
     ec = std::error_code(errno, std::system_category());
   }
-
-  int handle = open(path.data(), O_DIRECTORY);    // NOLINT(*-vararg)
 #endif
 
   if (ec) {
     throw fs::filesystem_error("Cannot create temporary directory", ec);
   }
+
+#ifdef _WIN32
+  HANDLE handle =
+      CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+#else
+  int handle = open(path.data(), O_DIRECTORY);    // NOLINT(*-vararg)
+#endif
 
   return std::pair(path, handle);
 }

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -57,7 +57,7 @@ fs::path create_directory(std::string_view label) {
 }    // namespace
 
 directory::directory(std::string_view label)
-    : entry(create_directory(label)) {}
+    : entry(create_directory(label), {}) {}
 
 directory directory::copy(const fs::path& path, std::string_view label) {
   std::error_code ec;

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -22,7 +22,7 @@ namespace {
 /// Creates a temporary directory with the given prefix in the system's
 /// temporary directory, and returns its path
 /// @param label    A label to attach to the temporary directory path
-/// @returns A path to the created temporary directory
+/// @returns A path to the created temporary file and a handle to it
 /// @throws fs::filesystem_error  if cannot create a temporary directory
 /// @throws std::invalid_argument if the label is ill-formatted
 std::pair<fs::path, entry::native_handle_type>
@@ -101,7 +101,6 @@ fs::directory_iterator directory::list() const {
 directory::~directory() noexcept = default;
 
 directory::directory(directory&&) noexcept = default;
-
 directory& directory::operator=(directory&&) noexcept = default;
 }    // namespace tmp
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -11,6 +11,14 @@
 namespace tmp {
 namespace {
 
+// Confirm that native_handle_type matches `TriviallyCopyable` named requirement
+static_assert(std::is_trivially_copyable_v<entry::native_handle_type>);
+
+#ifdef _WIN32
+// Confirm that `HANDLE` is `void*` as implemented in `entry`
+static_assert(std::is_same_v<HANDLE, void*>);
+#endif
+
 /// Deletes the given path recursively, ignoring any errors
 /// @param path     The path to delete
 void remove(const fs::path& path) noexcept {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -31,7 +31,7 @@ namespace {
 /// @returns A path to the created temporary file and a handle to it
 /// @throws fs::filesystem_error  if cannot create a temporary file
 /// @throws std::invalid_argument if the label or extension is ill-formatted
-std::pair<fs::path, file::native_handle_type>
+std::pair<fs::path, entry::native_handle_type>
 create_file(std::string_view label, std::string_view extension) {
   fs::path::string_type path = make_pattern(label, extension);
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -23,14 +23,6 @@
 namespace tmp {
 namespace {
 
-// Confirm that native_handle_type matches `TriviallyCopyable` named requirement
-static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
-
-#ifdef _WIN32
-// Confirm that `HANDLE` is `void*` as implemented in `file`
-static_assert(std::is_same_v<HANDLE, void*>);
-#endif
-
 /// Creates a temporary file with the given prefix in the system's
 /// temporary directory, and opens it for reading and writing
 ///

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -25,7 +25,6 @@ namespace {
 
 /// Creates a temporary file with the given prefix in the system's
 /// temporary directory, and opens it for reading and writing
-///
 /// @param label     A label to attach to the temporary file path
 /// @param extension An extension of the temporary file path
 /// @returns A path to the created temporary file and a handle to it

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -1,6 +1,8 @@
 #include <tmp/directory>
 #include <tmp/file>
 
+#include "utils.hpp"
+
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -10,29 +12,9 @@
 #include <stdexcept>
 #include <utility>
 
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#include <fcntl.h>
-#endif
-
 namespace tmp {
 
 namespace fs = std::filesystem;
-
-namespace {
-/// Checks if the given file handle is valid
-/// @param handle handle to check
-/// @returns @c true if the handle is valid, @c false otherwise
-bool native_handle_is_valid(entry::native_handle_type handle) {
-#ifdef _WIN32
-  BY_HANDLE_FILE_INFORMATION info;
-  return GetFileInformationByHandle(handle, &info);
-#else
-  return fcntl(handle, F_GETFD) != -1;
-#endif
-}
-}    // namespace
 
 /// Tests directory creation with label
 TEST(directory, create_with_label) {

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -27,7 +27,7 @@ namespace {
 /// Checks if the given file handle is valid
 /// @param handle handle to check
 /// @returns @c true if the handle is valid, @c false otherwise
-bool native_handle_is_valid(file::native_handle_type handle) {
+bool native_handle_is_valid(entry::native_handle_type handle) {
 #ifdef _WIN32
   BY_HANDLE_FILE_INFORMATION info;
   return GetFileInformationByHandle(handle, &info);
@@ -364,7 +364,7 @@ TEST(file, output_stream_append_text) {
 /// Tests that destructor removes a file
 TEST(file, destructor) {
   fs::path path = fs::path();
-  file::native_handle_type handle;
+  entry::native_handle_type handle;
   {
     file tmpfile = file();
     path = tmpfile;
@@ -393,8 +393,8 @@ TEST(file, move_assignment) {
   fs::path path1 = fst;
   fs::path path2 = snd;
 
-  file::native_handle_type fst_handle = fst.native_handle();
-  file::native_handle_type snd_handle = snd.native_handle();
+  entry::native_handle_type fst_handle = fst.native_handle();
+  entry::native_handle_type snd_handle = snd.native_handle();
 
   fst = std::move(snd);
 
@@ -411,7 +411,7 @@ TEST(file, move_assignment) {
 /// Tests file moving
 TEST(file, move) {
   fs::path path = fs::path();
-  file::native_handle_type handle;
+  entry::native_handle_type handle;
 
   fs::path to = fs::temp_directory_path() / "non-existing" / "parent";
   {
@@ -436,8 +436,8 @@ TEST(file, swap) {
 
   fs::path fst_path = fst.path();
   fs::path snd_path = snd.path();
-  file::native_handle_type fst_handle = fst.native_handle();
-  file::native_handle_type snd_handle = snd.native_handle();
+  entry::native_handle_type fst_handle = fst.native_handle();
+  entry::native_handle_type snd_handle = snd.native_handle();
 
   std::swap(fst, snd);
 

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -1,6 +1,8 @@
 #include <tmp/directory>
 #include <tmp/file>
 
+#include "utils.hpp"
+
 #include <gtest/gtest.h>
 
 #include <cstddef>
@@ -12,30 +14,9 @@
 #include <stdexcept>
 #include <utility>
 
-#ifdef _WIN32
-#include <Windows.h>
-#else
-#include <fcntl.h>
-#endif
-
 namespace tmp {
 
 namespace fs = std::filesystem;
-
-namespace {
-
-/// Checks if the given file handle is valid
-/// @param handle handle to check
-/// @returns @c true if the handle is valid, @c false otherwise
-bool native_handle_is_valid(entry::native_handle_type handle) {
-#ifdef _WIN32
-  BY_HANDLE_FILE_INFORMATION info;
-  return GetFileInformationByHandle(handle, &info);
-#else
-  return fcntl(handle, F_GETFD) != -1;
-#endif
-}
-}    // namespace
 
 /// Tests file creation with label
 TEST(file, create_with_label) {

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -13,7 +13,7 @@ namespace tmp {
 
 /// Checks if the given file handle is valid
 /// @param handle handle to check
-/// @returns @c true if the handle is valid, @c false otherwise
+/// @returns whether the handle is valid
 inline bool native_handle_is_valid(entry::native_handle_type handle) {
 #ifdef _WIN32
   BY_HANDLE_FILE_INFORMATION info;

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -1,0 +1,27 @@
+#ifndef TMP_TESTS_UTILS_H
+#define TMP_TESTS_UTILS_H
+
+#include <tmp/entry>
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <fcntl.h>
+#endif
+
+namespace tmp {
+
+/// Checks if the given file handle is valid
+/// @param handle handle to check
+/// @returns @c true if the handle is valid, @c false otherwise
+inline bool native_handle_is_valid(entry::native_handle_type handle) {
+#ifdef _WIN32
+  BY_HANDLE_FILE_INFORMATION info;
+  return GetFileInformationByHandle(handle, &info);
+#else
+  return fcntl(handle, F_GETFD) != -1;
+#endif
+}
+}    // namespace tmp
+
+#endif    // TMP_TESTS_UTILS_H


### PR DESCRIPTION
`tmp::entry` now owns a native handle to the opened resource and closes it when the path is deleted