### PR TITLE
Tidy up operators declaration

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -64,10 +64,10 @@ public:
   /// Deletes the managed directory recursively
   ~directory() noexcept override;
 
-  directory(directory&&) noexcept;               ///< move-constructible
-  directory& operator=(directory&&) noexcept;    ///< move-assignable
-  directory(const directory&) = delete;          ///< not copy-constructible
-  auto operator=(const directory&) = delete;     ///< not copy-assignable
+  directory(directory&&) noexcept;                    ///< MoveConstructible
+  directory& operator=(directory&&) noexcept;         ///< MoveAssignable
+  directory(const directory&) = delete;               ///< not CopyConstructible
+  directory& operator=(const directory&) = delete;    ///< not CopyAssignable
 
 private:
   /// Creates a unique temporary directory

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -50,8 +50,15 @@ public:
   /// Deletes the managed path recursively and closes its handle
   virtual ~entry() noexcept;
 
-  entry(const entry&) = delete;             ///< not copy-constructible
-  auto operator=(const entry&) = delete;    ///< not copy-assignable
+  entry(const entry&) = delete;               ///< not CopyConstructible
+  entry& operator=(const entry&) = delete;    ///< not CopyAssignable
+
+  bool operator==(const entry& rhs) const noexcept;    ///< EqualityComparable
+  bool operator!=(const entry& rhs) const noexcept;
+  bool operator<(const entry& rhs) const noexcept;    ///< LessThanComparable
+  bool operator>(const entry& rhs) const noexcept;
+  bool operator<=(const entry& rhs) const noexcept;
+  bool operator>=(const entry& rhs) const noexcept;
 
 protected:
   /// Creates a temporary entry which owns the given path
@@ -59,8 +66,8 @@ protected:
   /// @param handle    An implementation-defined handle to this entry
   explicit entry(std::filesystem::path path, native_handle_type handle);
 
-  entry(entry&&) noexcept;               ///< move-constructible
-  entry& operator=(entry&&) noexcept;    ///< move-assignable
+  entry(entry&&) noexcept;               ///< MoveConstructible
+  entry& operator=(entry&&) noexcept;    ///< MoveAssignable
 
 private:
   /// The managed path
@@ -74,24 +81,6 @@ private:
   /// @returns The full path this entry manages
   std::filesystem::path release() noexcept TMP_NO_EXPORT;
 };
-
-/// Checks whether lhs and rhs are equal
-bool operator==(const entry& lhs, const entry& rhs) noexcept TMP_EXPORT;
-
-/// Checks whether lhs and rhs are not equal
-bool operator!=(const entry& lhs, const entry& rhs) noexcept TMP_EXPORT;
-
-/// Checks whether lhs is less than rhs
-bool operator<(const entry& lhs, const entry& rhs) noexcept TMP_EXPORT;
-
-/// Checks whether lhs is less than or equal to rhs
-bool operator<=(const entry& lhs, const entry& rhs) noexcept TMP_EXPORT;
-
-/// Checks whether lhs is greater than rhs
-bool operator>(const entry& lhs, const entry& rhs) noexcept TMP_EXPORT;
-
-/// Checks whether lhs is greater than or equal to rhs
-bool operator>=(const entry& lhs, const entry& rhs) noexcept TMP_EXPORT;
 }    // namespace tmp
 
 /// The template specialization of `std::hash` for `tmp::entry`

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -97,10 +97,10 @@ public:
   /// Deletes the managed file
   ~file() noexcept override;
 
-  file(file&&) noexcept;                   ///< move-constructible
-  file& operator=(file&&) noexcept;        ///< move-assignable
-  file(const file&) = delete;              ///< not copy-constructible
-  auto operator=(const file&) = delete;    ///< not copy-assignable
+  file(file&&) noexcept;                    ///< MoveConstructible
+  file& operator=(file&&) noexcept;         ///< MoveAssignable
+  file(const file&) = delete;               ///< not CopyConstructible
+  file& operator=(const file&) = delete;    ///< not CopyAssignable
 
 private:
   /// Whether the managed file is opened in binary write mode

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -129,28 +129,28 @@ fs::path entry::release() noexcept {
   return path;
 }
 
-bool operator==(const entry& lhs, const entry& rhs) noexcept {
-  return lhs.path() == rhs.path();
+bool entry::operator==(const entry& rhs) const noexcept {
+  return path() == rhs.path();
 }
 
-bool operator!=(const entry& lhs, const entry& rhs) noexcept {
-  return lhs.path() != rhs.path();
+bool entry::operator!=(const entry& rhs) const noexcept {
+  return path() != rhs.path();
 }
 
-bool operator<(const entry& lhs, const entry& rhs) noexcept {
-  return lhs.path() < rhs.path();
+bool entry::operator<(const entry& rhs) const noexcept {
+  return path() < rhs.path();
 }
 
-bool operator<=(const entry& lhs, const entry& rhs) noexcept {
-  return lhs.path() <= rhs.path();
+bool entry::operator<=(const entry& rhs) const noexcept {
+  return path() <= rhs.path();
 }
 
-bool operator>(const entry& lhs, const entry& rhs) noexcept {
-  return lhs.path() > rhs.path();
+bool entry::operator>(const entry& rhs) const noexcept {
+  return path() > rhs.path();
 }
 
-bool operator>=(const entry& lhs, const entry& rhs) noexcept {
-  return lhs.path() >= rhs.path();
+bool entry::operator>=(const entry& rhs) const noexcept {
+  return path() >= rhs.path();
 }
 }    // namespace tmp
 


### PR DESCRIPTION
- Make relational operators members of `tmp::entry` as in `std::directory_entry`
- Do not use `auto` in deleted constructors
- Use Named Requirements terminology in docs