### PR TITLE
Inherit hash from `tmp::entry`

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -4,7 +4,6 @@
 #include <tmp/entry>
 #include <tmp/export>
 
-#include <cstddef>
 #include <filesystem>
 #include <string_view>
 #include <system_error>
@@ -90,8 +89,6 @@ public:
 }    // namespace tmp
 
 /// The template specialization of `std::hash` for `tmp::directory`
-template<> struct TMP_EXPORT std::hash<tmp::directory> {
-  std::size_t operator()(const tmp::directory& directory) const noexcept;
-};
+template<> struct std::hash<tmp::directory> : std::hash<tmp::entry> {};
 
 #endif    // TMP_DIRECTORY_H

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -3,7 +3,6 @@
 
 #include <tmp/export>
 
-#include <cstddef>
 #include <filesystem>
 #include <system_error>
 #include <utility>

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -94,8 +94,6 @@ private:
 }    // namespace tmp
 
 /// The template specialization of `std::hash` for `tmp::entry`
-template<> struct TMP_EXPORT std::hash<tmp::entry> {
-  std::size_t operator()(const tmp::entry& entry) const noexcept;
-};
+template<> struct std::hash<tmp::entry> : std::hash<std::filesystem::path> {};
 
 #endif    // TMP_ENTRY_H

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -3,6 +3,7 @@
 
 #include <tmp/export>
 
+#include <cstddef>
 #include <filesystem>
 #include <system_error>
 #include <utility>
@@ -93,6 +94,8 @@ private:
 }    // namespace tmp
 
 /// The template specialization of `std::hash` for `tmp::entry`
-template<> struct std::hash<tmp::entry> : std::hash<std::filesystem::path> {};
+template<> struct TMP_EXPORT std::hash<tmp::entry> {
+  std::size_t operator()(const tmp::entry& entry) const noexcept;
+};
 
 #endif    // TMP_ENTRY_H

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -4,7 +4,6 @@
 #include <tmp/entry>
 #include <tmp/export>
 
-#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <ios>
@@ -173,8 +172,6 @@ private:
 }    // namespace tmp
 
 /// The template specialization of `std::hash` for `tmp::file`
-template<> struct TMP_EXPORT std::hash<tmp::file> {
-  std::size_t operator()(const tmp::file& file) const noexcept;
-};
+template<> struct std::hash<tmp::file> : std::hash<tmp::entry> {};
 
 #endif    // TMP_FILE_H

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -3,7 +3,6 @@
 
 #include "create.hpp"
 
-#include <cstddef>
 #include <filesystem>
 #include <string_view>
 #include <system_error>
@@ -65,8 +64,3 @@ directory::~directory() noexcept = default;
 directory::directory(directory&&) noexcept = default;
 directory& directory::operator=(directory&&) noexcept = default;
 }    // namespace tmp
-
-std::size_t std::hash<tmp::directory>::operator()(
-    const tmp::directory& directory) const noexcept {
-  return std::hash<tmp::entry>()(directory);
-}

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -2,6 +2,7 @@
 
 #include "create.hpp"
 
+#include <cstddef>
 #include <filesystem>
 #include <new>
 #include <system_error>
@@ -203,3 +204,9 @@ bool entry::operator>=(const entry& rhs) const noexcept {
   return path() >= rhs.path();
 }
 }    // namespace tmp
+
+std::size_t
+std::hash<tmp::entry>::operator()(const tmp::entry& entry) const noexcept {
+  // `std::hash<std::filesystem::path>` was not included in the C++17 standard
+  return filesystem::hash_value(entry);
+}

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -2,7 +2,6 @@
 
 #include "create.hpp"
 
-#include <cstddef>
 #include <filesystem>
 #include <new>
 #include <system_error>
@@ -204,8 +203,3 @@ bool entry::operator>=(const entry& rhs) const noexcept {
   return path() >= rhs.path();
 }
 }    // namespace tmp
-
-std::size_t
-std::hash<tmp::entry>::operator()(const tmp::entry& entry) const noexcept {
-  return tmp::fs::hash_value(entry);
-}

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -322,8 +322,3 @@ file::~file() noexcept = default;
 file::file(file&&) noexcept = default;
 file& file::operator=(file&& other) noexcept = default;
 }    // namespace tmp
-
-std::size_t
-std::hash<tmp::file>::operator()(const tmp::file& file) const noexcept {
-  return std::hash<tmp::entry>()(file);
-}


### PR DESCRIPTION
Explicitly inherit hash `operator()` from `tmp::entry`

Breaks ABI, so will be included in future versions