### PR TITLE
Set WARNING_AS_ERROR in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Configure CMake
-        run: cmake -B build
+        run: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
       - name: Build tests
         run: cmake --build build
       - name: Run tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,12 +21,10 @@ target_include_directories(${PROJECT_NAME}
 
 if(TMP_IS_TOP_LEVEL)
   if(CMAKE_CXX_COMPILER_ID MATCHES GNU|Clang)
-    target_compile_options(${PROJECT_NAME} PRIVATE -Werror)
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic)
   elseif(MSVC)
     # FIXME: warning C4251 for 'tmp::entry::pathobject'
-    # target_compile_options(${PROJECT_NAME} PRIVATE /WX)
-    target_compile_options(${PROJECT_NAME} PRIVATE /W3)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W3 /wd4251)
   endif()
 endif()
 


### PR DESCRIPTION
Set flags like `-Werror` and `/WX` in CI and not in local builds