### PR TITLE
Delete directory private constructor

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -68,12 +68,6 @@ public:
   directory& operator=(directory&&) noexcept;         ///< MoveAssignable
   directory(const directory&) = delete;               ///< not CopyConstructible
   directory& operator=(const directory&) = delete;    ///< not CopyAssignable
-
-private:
-  /// Creates a unique temporary directory
-  /// @param handle    A path to the created temporary directory and its handle
-  directory(std::pair<std::filesystem::path, native_handle_type>
-                handle) noexcept TMP_NO_EXPORT;
 };
 }    // namespace tmp
 

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <utility>
 
 namespace tmp {
 
@@ -61,10 +62,14 @@ public:
   bool operator>=(const entry& rhs) const noexcept;
 
 protected:
-  /// Creates a temporary entry which owns the given path
+  /// Creates a temporary entry which owns the given path and handle
   /// @param path      A path to manage
   /// @param handle    An implementation-defined handle to this entry
   explicit entry(std::filesystem::path path, native_handle_type handle);
+
+  /// Creates a temporary entry which owns the given path and handle
+  /// @param handle    A pair of a path and a handle to manage
+  explicit entry(std::pair<std::filesystem::path, native_handle_type> handle);
 
   entry(entry&&) noexcept;               ///< MoveConstructible
   entry& operator=(entry&&) noexcept;    ///< MoveAssignable

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -68,11 +68,8 @@ create_directory(std::string_view label) {
 }
 }    // namespace
 
-directory::directory(std::pair<fs::path, native_handle_type> handle) noexcept
-    : entry(std::move(handle.first), handle.second) {}
-
 directory::directory(std::string_view label)
-    : directory(create_directory(label)) {}
+    : entry(create_directory(label)) {}
 
 directory directory::copy(const fs::path& path, std::string_view label) {
   std::error_code ec;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -71,6 +71,9 @@ void remove(const fs::path& path) noexcept {
 }
 }    // namespace
 
+entry::entry(std::pair<fs::path, native_handle_type> handle)
+    : entry(std::move(handle.first), handle.second) {}
+
 entry::entry(fs::path path, native_handle_type handle)
     : pathobject(std::move(path)),
       handle(handle) {}


### PR DESCRIPTION
- To keep public headers clean
- To provide a more convinient entry constructor from a pair