### PR TITLE
Update used macos images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-24.04
-          - macos-12
-          - macos-14
+          - macos-13
+          - macos-15
           - windows-2019
           - windows-2022
     steps:


### PR DESCRIPTION
- macos 12 is now deprecated:
  (https://github.com/actions/runner-images/issues/10721)
- macos 15 is now available:
  (https://github.com/actions/runner-images/issues/10686)