### PR TITLE
Set up `tmpfs` on Linux systems

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
           - windows-2019
           - windows-2022
     steps:
+      - name: Set up `tmpfs` (if supported)
+        run: sudo mount tmpfs -t tmpfs -o size=100m /tmp
+        if: runner.os == 'Linux'
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Configure CMake


### PR DESCRIPTION
Apparently, Ubuntu images in Github Actions do not have `/tmp` in `tmpfs` and `TMPDIR` is not set