### PR TITLE
Fix `tmp::entry::move` method

### DIFF
--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -42,7 +42,8 @@ public:
   native_handle_type native_handle() const noexcept;
 
   /// Moves the managed path recursively to a given target, releasing
-  /// ownership of the managed path
+  /// ownership of the managed path; behaves like `std::filesystem::rename`
+  /// even when moving between filesystems
   /// @note The target path parent is created when this function is called
   /// @param to        A path to the target file or directory
   /// @throws std::filesystem::filesystem_error if cannot move the owned path

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -129,6 +129,11 @@ void entry::move(const fs::path& to) {
       throw_move_error(to, ec);
     }
 
+    if (fs::is_directory(*this) && fs::is_regular_file(to)) {
+      ec = std::make_error_code(std::errc::not_a_directory);
+      throw_move_error(to, ec);
+    }
+
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
     remove(*this);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -139,7 +139,6 @@ void entry::move(const fs::path& to) {
   // between drives; in that case we copy the directory manually
   if (fs::is_directory(*this) && path().root_name() != to.root_name()) {
     fs::copy(*this, to, copy_options, ec);
-    remove(*this);
   } else {
     fs::rename(*this, to, ec);
   }
@@ -151,12 +150,15 @@ void entry::move(const fs::path& to) {
   if (ec == std::errc::cross_device_link) {
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
-    remove(*this);
   }
 #endif
 
   if (ec) {
     throw_move_error(to, ec);
+  }
+
+  if (fs::exists(*this) && !fs::equivalent(*this, to)) {
+    remove(*this);
   }
 
   pathobject.clear();

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -123,9 +123,17 @@ void entry::move(const fs::path& to) {
       throw_move_error(to, ec);
     }
 
-    if (fs::is_directory(*this) && !fs::is_directory(to)) {
-      ec = std::make_error_code(std::errc::not_a_directory);
-      throw_move_error(to, ec);
+    if (fs::is_directory(*this)) {
+      if (!fs::is_directory(to)) {
+        ec = std::make_error_code(std::errc::not_a_directory);
+        throw_move_error(to, ec);
+      }
+
+#ifdef WIN32
+      if (!fs::equivalent(path(), to)) {
+        fs::remove_all(to);
+      }
+#endif
     }
   }
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -136,7 +136,7 @@ void entry::move(const fs::path& to) {
         throw_move_error(to, ec);
       }
 
-#ifdef WIN32
+#ifdef _WIN32
       if (!fs::equivalent(path(), to)) {
         fs::remove_all(to);
       }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -4,7 +4,6 @@
 
 #include <cstddef>
 #include <filesystem>
-#include <iostream>
 #include <new>
 #include <system_error>
 #include <type_traits>
@@ -125,7 +124,6 @@ void entry::move(const fs::path& to) {
 
   fs::rename(*this, to, ec);
   if (ec == std::errc::cross_device_link) {
-    std::cout << "copying" << std::endl;
     if (fs::is_regular_file(*this) && fs::is_directory(to)) {
       ec = std::make_error_code(std::errc::is_a_directory);
       throw_move_error(to, ec);
@@ -133,8 +131,6 @@ void entry::move(const fs::path& to) {
 
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
-  } else {
-    std::cout << "renaming" << std::endl;
   }
 
   if (ec) {

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -33,6 +33,13 @@ const entry::native_handle_type invalid_handle = nullptr;
 const entry::native_handle_type invalid_handle = -1;
 #endif
 
+/// Cross-volume (cross-device) platform-dependent error code
+#ifdef _WIN32
+const std::errc cross_device_copy = std::errc::permission_denied;
+#else
+const std::errc cross_device_copy = std::errc::cross_device_link;
+#endif
+
 /// Closes the given entry, ignoring any errors
 /// @param entry     The entry to close
 void close(const entry& entry) noexcept {
@@ -143,7 +150,7 @@ void entry::move(const fs::path& to) {
   }
 
   fs::rename(*this, to, ec);
-  if (ec == std::errc::cross_device_link || ec == std::errc::permission_denied) {
+  if (ec == cross_device_copy) {
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
     remove(*this);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -131,13 +131,13 @@ void entry::move(const fs::path& to) {
 
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
+    remove(*this);
   }
 
   if (ec) {
     throw_move_error(to, ec);
   }
 
-  remove(*this);
   pathobject.clear();
 }
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -143,7 +143,7 @@ void entry::move(const fs::path& to) {
   }
 
   fs::rename(*this, to, ec);
-  if (ec == std::errc::cross_device_link) {
+  if (ec == std::errc::cross_device_link || ec == std::errc::permission_denied) {
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
     remove(*this);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -117,6 +117,16 @@ entry::native_handle_type entry::native_handle() const noexcept {
 
 void entry::move(const fs::path& to) {
   std::error_code ec;
+  if (fs::is_regular_file(*this) && fs::is_directory(to)) {
+    ec = std::make_error_code(std::errc::is_a_directory);
+    throw_move_error(to, ec);
+  }
+
+  if (fs::is_directory(*this) && fs::is_regular_file(to)) {
+    ec = std::make_error_code(std::errc::not_a_directory);
+    throw_move_error(to, ec);
+  }
+
   create_parent(to, ec);
   if (ec) {
     throw_move_error(to, ec);
@@ -124,16 +134,6 @@ void entry::move(const fs::path& to) {
 
   fs::rename(*this, to, ec);
   if (ec == std::errc::cross_device_link) {
-    if (fs::is_regular_file(*this) && fs::is_directory(to)) {
-      ec = std::make_error_code(std::errc::is_a_directory);
-      throw_move_error(to, ec);
-    }
-
-    if (fs::is_directory(*this) && fs::is_regular_file(to)) {
-      ec = std::make_error_code(std::errc::not_a_directory);
-      throw_move_error(to, ec);
-    }
-
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
     remove(*this);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -117,14 +117,16 @@ entry::native_handle_type entry::native_handle() const noexcept {
 
 void entry::move(const fs::path& to) {
   std::error_code ec;
-  if (fs::is_regular_file(*this) && fs::is_directory(to)) {
-    ec = std::make_error_code(std::errc::is_a_directory);
-    throw_move_error(to, ec);
-  }
+  if (fs::exists(to)) {
+    if (!fs::is_directory(*this) && fs::is_directory(to)) {
+      ec = std::make_error_code(std::errc::is_a_directory);
+      throw_move_error(to, ec);
+    }
 
-  if (fs::is_directory(*this) && fs::is_regular_file(to)) {
-    ec = std::make_error_code(std::errc::not_a_directory);
-    throw_move_error(to, ec);
+    if (fs::is_directory(*this) && !fs::is_directory(to)) {
+      ec = std::make_error_code(std::errc::not_a_directory);
+      throw_move_error(to, ec);
+    }
   }
 
   create_parent(to, ec);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <iostream>
 #include <new>
 #include <system_error>
 #include <type_traits>
@@ -124,6 +125,7 @@ void entry::move(const fs::path& to) {
 
   fs::rename(*this, to, ec);
   if (ec == std::errc::cross_device_link) {
+    std::cout << "copying" << std::endl;
     if (fs::is_regular_file(*this) && fs::is_directory(to)) {
       ec = std::make_error_code(std::errc::is_a_directory);
       throw_move_error(to, ec);
@@ -131,6 +133,8 @@ void entry::move(const fs::path& to) {
 
     fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
+  } else {
+    std::cout << "renaming" << std::endl;
   }
 
   if (ec) {

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -149,6 +149,7 @@ void entry::move(const fs::path& to) {
   // so we try to rename the file, and if we fail with `EXDEV`, move it manually
   fs::rename(*this, to, ec);
   if (ec == std::errc::cross_device_link) {
+    fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
     remove(*this);
   }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -135,8 +135,9 @@ void entry::move(const fs::path& to) {
   }
 
 #ifdef _WIN32
+  // On Windows, the underlying `MoveFileExW` fails when moving a directory
+  // between drives; in that case we copy the directory manually
   if (fs::is_directory(*this) && path().root_name() != to.root_name()) {
-    fs::remove_all(to);
     fs::copy(*this, to, copy_options, ec);
     remove(*this);
   } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,8 @@ find_package(GTest)
 add_executable(${PROJECT_NAME} directory.cpp file.cpp)
 target_link_libraries(${PROJECT_NAME} tmp::tmp GTest::gtest_main)
 target_compile_definitions(${PROJECT_NAME}
-  PRIVATE LABEL="com.github.bugdea1er.tmp")
+  PRIVATE LABEL="com.github.bugdea1er.tmp"
+  BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
 # On some platforms (e.g. Windows) CMake doesn't write load paths properly
 # This solution to put outputs in the same directory is good enough

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ project(${PROJECT_NAME}.test)
 
 find_package(GTest)
 
-add_executable(${PROJECT_NAME} directory.cpp file.cpp)
+add_executable(${PROJECT_NAME} entry.cpp directory.cpp file.cpp)
 target_link_libraries(${PROJECT_NAME} tmp::tmp GTest::gtest_main)
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE LABEL="com.github.bugdea1er.tmp"

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -120,7 +120,7 @@ TEST(directory, list) {
 
 /// Tests that destructor removes a directory
 TEST(directory, destructor) {
-  fs::path path = fs::path();
+  fs::path path;
   entry::native_handle_type handle;
   {
     directory tmpdir = directory();
@@ -174,7 +174,7 @@ TEST(directory, move_assignment) {
 
 /// Tests directory moving
 TEST(directory, move) {
-  fs::path path = fs::path();
+  fs::path path;
   entry::native_handle_type handle;
 
   fs::path to = fs::temp_directory_path() / "non-existing" / "parent";

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -172,27 +172,6 @@ TEST(directory, move_assignment) {
   EXPECT_TRUE(native_handle_is_valid(fst.native_handle()));
 }
 
-/// Tests directory moving
-TEST(directory, move) {
-  fs::path path;
-  entry::native_handle_type handle;
-
-  fs::path to = fs::temp_directory_path() / "non-existing" / "parent";
-  {
-    directory tmpdir = directory();
-    path = tmpdir;
-    handle = tmpdir.native_handle();
-
-    tmpdir.move(to);
-  }
-
-  EXPECT_FALSE(fs::exists(path));
-  EXPECT_TRUE(fs::exists(to));
-  EXPECT_FALSE(native_handle_is_valid(handle));
-
-  fs::remove_all(fs::temp_directory_path() / "non-existing");
-}
-
 /// Tests directory swapping
 TEST(directory, swap) {
   directory fst = directory();

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -49,9 +49,11 @@ TEST(entry, move_file_to_self) {
   EXPECT_TRUE(fs::exists(path));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  auto stream = std::ifstream(path);
-  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-  EXPECT_EQ(content, "Hello, world!");
+  {
+    auto stream = std::ifstream(path);
+    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
 
   fs::remove_all(path);
 }
@@ -76,9 +78,11 @@ TEST(entry, move_file_to_existing_file) {
   EXPECT_FALSE(fs::exists(path));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  auto stream = std::ifstream(to);
-  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-  EXPECT_EQ(content, "Hello, world!");
+  {
+    auto stream = std::ifstream(to);
+    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
 
   fs::remove_all(path);
 }
@@ -113,9 +117,11 @@ TEST(entry, move_file_to_non_existing_file) {
   EXPECT_FALSE(fs::exists(path));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  auto stream = std::ifstream(to);
-  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-  EXPECT_EQ(content, "Hello, world!");
+  {
+    auto stream = std::ifstream(to);
+    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
 
   fs::remove_all(parent);
 }
@@ -146,9 +152,11 @@ TEST(entry, move_directory_to_self) {
   EXPECT_TRUE(fs::exists(path));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  auto stream = std::ifstream(path / "file");
-  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-  EXPECT_EQ(content, "Hello, world!");
+  {
+    auto stream = std::ifstream(path / "file");
+    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
 
   fs::remove_all(path);
 }
@@ -173,9 +181,11 @@ TEST(entry, move_directory_to_existing_directory) {
   EXPECT_FALSE(fs::exists(path));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  auto stream = std::ifstream(to / "file");
-  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-  EXPECT_EQ(content, "Hello, world!");
+  {
+    auto stream = std::ifstream(to / "file");
+    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
 
   EXPECT_FALSE(fs::exists(to / "file2"));
 
@@ -212,9 +222,11 @@ TEST(entry, move_directory_to_non_existing_path) {
   EXPECT_FALSE(fs::exists(path));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  auto stream = std::ifstream(to / "file");
-  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-  EXPECT_EQ(content, "Hello, world!");
+  {
+    auto stream = std::ifstream(to / "file");
+    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
 
   fs::remove_all(parent);
 }

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -1,0 +1,76 @@
+#include <tmp/directory>
+#include <tmp/entry>
+#include <tmp/file>
+
+#include "utils.hpp"
+
+#include <gtest/gtest.h>
+
+namespace tmp {
+namespace {
+
+namespace fs = std::filesystem;
+
+/// Returns a temporary file containing `Hello world!`
+file test_file() {
+  file tmpfile = file();
+  tmpfile.write("Hello, world!");
+
+  return tmpfile;
+}
+
+/// Returns a temporary directory with a file containing `Hello world!`
+directory test_directory() {
+  directory tmpdir = directory();
+  std::ofstream(tmpdir / "file") << "Hello, world!";
+
+  return tmpdir;
+}
+}    // namespace
+
+/// Tests that moving a temporary file to itself does nothing
+TEST(entry, move_file_to_self) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  {
+    file tmpfile = test_file();
+    path = tmpfile;
+    handle = tmpfile.native_handle();
+
+    tmpfile.move(tmpfile);
+  }
+
+  EXPECT_TRUE(fs::exists(path));
+  EXPECT_FALSE(native_handle_is_valid(handle));
+
+  auto stream = std::ifstream(path);
+  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+  EXPECT_EQ(content, "Hello, world!");
+
+  fs::remove_all(path);
+}
+
+/// Tests that moving a temporary directory to itself does nothing
+TEST(entry, move_directory_to_self) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  {
+    directory tmpdir = test_directory();
+    path = tmpdir;
+    handle = tmpdir.native_handle();
+
+    tmpdir.move(tmpdir);
+  }
+
+  EXPECT_TRUE(fs::exists(path));
+  EXPECT_FALSE(native_handle_is_valid(handle));
+
+  auto stream = std::ifstream(path / "file");
+  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+  EXPECT_EQ(content, "Hello, world!");
+
+  fs::remove_all(path);
+}
+}    // namespace tmp

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -84,7 +84,7 @@ TEST(entry, move_file_to_existing_file) {
     EXPECT_EQ(content, "Hello, world!");
   }
 
-  fs::remove_all(path);
+  fs::remove_all(to);
 }
 
 /// Tests moving a temporary file to an existing directory

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -102,7 +102,7 @@ TEST(entry, move_file_to_non_existing_file) {
   fs::path path;
   entry::native_handle_type handle;
 
-  fs::path parent = fs::path(BUILD_DIR) / "non-existing";
+  fs::path parent = fs::path(BUILD_DIR) / "non-existing1";
   fs::path to = parent / "path";
 
   {
@@ -128,7 +128,7 @@ TEST(entry, move_file_to_non_existing_file) {
 
 /// Tests moving a temporary file to a non-existing directory
 TEST(entry, move_file_to_non_existing_directory) {
-  fs::path parent = fs::path(BUILD_DIR) / "non-existing";
+  fs::path parent = fs::path(BUILD_DIR) / "non-existing2";
   fs::path to = parent / "path/";
 
   EXPECT_THROW(test_file().move(to), fs::filesystem_error);
@@ -207,7 +207,7 @@ TEST(entry, move_directory_to_non_existing_path) {
   fs::path path;
   entry::native_handle_type handle;
 
-  fs::path parent = fs::path(BUILD_DIR) / "non-existing";
+  fs::path parent = fs::path(BUILD_DIR) / "non-existing3";
   fs::path to = parent / "path";
 
   {

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -5,7 +5,11 @@
 #include "utils.hpp"
 
 #include <gtest/gtest.h>
+
 #include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
 
 namespace tmp {
 namespace {

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -96,8 +96,8 @@ TEST(entry, move_file_to_existing_directory) {
   fs::remove_all(directory);
 }
 
-/// Tests moving a temporary file to non-existing path
-TEST(entry, move_file_to_non_existing_path) {
+/// Tests moving a temporary file to a non-existing file
+TEST(entry, move_file_to_non_existing_file) {
   fs::path path;
   entry::native_handle_type handle;
 
@@ -119,6 +119,19 @@ TEST(entry, move_file_to_non_existing_path) {
   auto stream = std::ifstream(to);
   auto content = std::string(std::istreambuf_iterator<char>(stream), {});
   EXPECT_EQ(content, "Hello, world!");
+
+  fs::remove_all(parent);
+}
+
+/// Tests moving a temporary file to a non-existing directory
+TEST(entry, move_file_to_non_existing_directory) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  fs::path parent = fs::path(BUILD_DIR) / "non-existing";
+  fs::path to = parent / "path/";
+
+  EXPECT_THROW(test_file().move(to), fs::filesystem_error);
 
   fs::remove_all(parent);
 }

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -191,4 +191,31 @@ TEST(entry, move_directory_to_existing_file) {
 
   fs::remove_all(to);
 }
+
+/// Tests moving a temporary directory to a non-existing path
+TEST(entry, move_directory_to_non_existing_path) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  fs::path parent = fs::path(BUILD_DIR) / "non-existing";
+  fs::path to = parent / "path";
+
+  {
+    directory tmpdir = test_directory();
+    path = tmpdir;
+    handle = tmpdir.native_handle();
+
+    tmpdir.move(to);
+  }
+
+  EXPECT_TRUE(fs::exists(to));
+  EXPECT_FALSE(fs::exists(path));
+  EXPECT_FALSE(native_handle_is_valid(handle));
+
+  auto stream = std::ifstream(to / "file");
+  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+  EXPECT_EQ(content, "Hello, world!");
+
+  fs::remove_all(parent);
+}
 }    // namespace tmp

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -78,6 +78,33 @@ TEST(entry, move_file_to_existing) {
   fs::remove_all(path);
 }
 
+/// Tests moving a temporary file to non-existing path
+TEST(entry, move_file_to_non_existing) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  fs::path parent = fs::path(BUILD_DIR) / "non-existing";
+  fs::path to = parent / "path";
+
+  {
+    file tmpfile = test_file();
+    path = tmpfile;
+    handle = tmpfile.native_handle();
+
+    tmpfile.move(to);
+  }
+
+  EXPECT_TRUE(fs::exists(to));
+  EXPECT_FALSE(fs::exists(path));
+  EXPECT_FALSE(native_handle_is_valid(handle));
+
+  auto stream = std::ifstream(to);
+  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+  EXPECT_EQ(content, "Hello, world!");
+
+  fs::remove_all(parent);
+}
+
 /// Tests that moving a temporary directory to itself does nothing
 TEST(entry, move_directory_to_self) {
   fs::path path;

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -169,6 +169,10 @@ TEST(entry, move_directory_to_existing_directory) {
   fs::path to = fs::path(BUILD_DIR) / "move_directory_to_existing_test";
   std::ofstream(to / "file2") << "Goodbye, world!";
 
+#ifdef WIN32
+  // On Windows, `std::filesystem::rename` actually behaves differently here
+  EXPECT_THROW(test_directory().move(to), fs::filesystem_error);
+#else
   {
     directory tmpdir = test_directory();
     path = tmpdir;
@@ -188,7 +192,7 @@ TEST(entry, move_directory_to_existing_directory) {
   }
 
   EXPECT_FALSE(fs::exists(to / "file2"));
-
+#endif
   fs::remove_all(to);
 }
 

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -5,6 +5,7 @@
 #include "utils.hpp"
 
 #include <gtest/gtest.h>
+#include <filesystem>
 
 namespace tmp {
 namespace {
@@ -52,7 +53,7 @@ TEST(entry, move_file_to_self) {
 }
 
 /// Tests moving a temporary file to existing non-directory file
-TEST(entry, move_file_to_existing) {
+TEST(entry, move_file_to_existing_file) {
   fs::path path;
   entry::native_handle_type handle;
 
@@ -78,8 +79,21 @@ TEST(entry, move_file_to_existing) {
   fs::remove_all(path);
 }
 
+/// Tests moving a temporary file to an existing directory
+TEST(entry, move_file_to_existing_directory) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  fs::path directory = fs::path(BUILD_DIR) / "existing";
+  fs::create_directories(directory);
+
+  EXPECT_THROW(test_file().move(directory), fs::filesystem_error);
+
+  fs::remove_all(directory);
+}
+
 /// Tests moving a temporary file to non-existing path
-TEST(entry, move_file_to_non_existing) {
+TEST(entry, move_file_to_non_existing_path) {
   fs::path path;
   entry::native_handle_type handle;
 

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -85,9 +85,6 @@ TEST(entry, move_file_to_existing_file) {
 
 /// Tests moving a temporary file to an existing directory
 TEST(entry, move_file_to_existing_directory) {
-  fs::path path;
-  entry::native_handle_type handle;
-
   fs::path directory = fs::path(BUILD_DIR) / "existing";
   fs::create_directories(directory);
 
@@ -125,9 +122,6 @@ TEST(entry, move_file_to_non_existing_file) {
 
 /// Tests moving a temporary file to a non-existing directory
 TEST(entry, move_file_to_non_existing_directory) {
-  fs::path path;
-  entry::native_handle_type handle;
-
   fs::path parent = fs::path(BUILD_DIR) / "non-existing";
   fs::path to = parent / "path/";
 

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -169,10 +169,6 @@ TEST(entry, move_directory_to_existing_directory) {
   fs::path to = fs::path(BUILD_DIR) / "move_directory_to_existing_test";
   std::ofstream(to / "file2") << "Goodbye, world!";
 
-#ifdef WIN32
-  // On Windows, `std::filesystem::rename` actually behaves differently here
-  EXPECT_THROW(test_directory().move(to), fs::filesystem_error);
-#else
   {
     directory tmpdir = test_directory();
     path = tmpdir;
@@ -192,7 +188,7 @@ TEST(entry, move_directory_to_existing_directory) {
   }
 
   EXPECT_FALSE(fs::exists(to / "file2"));
-#endif
+
   fs::remove_all(to);
 }
 

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -51,6 +51,33 @@ TEST(entry, move_file_to_self) {
   fs::remove_all(path);
 }
 
+/// Tests moving a temporary file to existing non-directory file
+TEST(entry, move_file_to_existing) {
+  fs::path path;
+  entry::native_handle_type handle;
+
+  fs::path to = fs::path(BUILD_DIR) / "move_file_to_existing_test";
+  std::ofstream(to / "file") << "Goodbye, world!";
+
+  {
+    file tmpfile = test_file();
+    path = tmpfile;
+    handle = tmpfile.native_handle();
+
+    tmpfile.move(to);
+  }
+
+  EXPECT_TRUE(fs::exists(to));
+  EXPECT_FALSE(fs::exists(path));
+  EXPECT_FALSE(native_handle_is_valid(handle));
+
+  auto stream = std::ifstream(to);
+  auto content = std::string(std::istreambuf_iterator<char>(stream), {});
+  EXPECT_EQ(content, "Hello, world!");
+
+  fs::remove_all(path);
+}
+
 /// Tests that moving a temporary directory to itself does nothing
 TEST(entry, move_directory_to_self) {
   fs::path path;

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -414,8 +414,6 @@ TEST(file, move) {
   EXPECT_FALSE(native_handle_is_valid(handle));
 
   fs::remove_all(fs::path(BUILD_DIR) / "non-existing");
-
-  FAIL();
 }
 
 /// Tests file swapping

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -340,7 +340,7 @@ TEST(file, output_stream_append_text) {
 
 /// Tests that destructor removes a file
 TEST(file, destructor) {
-  fs::path path = fs::path();
+  fs::path path;
   entry::native_handle_type handle;
   {
     file tmpfile = file();
@@ -394,7 +394,7 @@ TEST(file, move_assignment) {
 
 /// Tests file moving
 TEST(file, move) {
-  fs::path path = fs::path();
+  fs::path path;
   entry::native_handle_type handle;
 
   fs::path to = fs::path(BUILD_DIR) / "non-existing" / "parent";

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -397,11 +397,14 @@ TEST(file, move) {
   fs::path path = fs::path();
   entry::native_handle_type handle;
 
-  fs::path to = fs::temp_directory_path() / "non-existing" / "parent";
+  fs::path to = fs::path(BUILD_DIR) / "non-existing" / "parent";
   {
     file tmpfile = file();
     path = tmpfile;
     handle = tmpfile.native_handle();
+
+    std::cout << "from: " << tmpfile.path() << std::endl;
+    std::cout << "to: " << to << std::endl;
 
     tmpfile.move(to);
   }
@@ -410,7 +413,9 @@ TEST(file, move) {
   EXPECT_TRUE(fs::exists(to));
   EXPECT_FALSE(native_handle_is_valid(handle));
 
-  fs::remove_all(fs::temp_directory_path() / "non-existing");
+  fs::remove_all(fs::path(BUILD_DIR) / "non-existing");
+
+  FAIL();
 }
 
 /// Tests file swapping

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -392,27 +392,6 @@ TEST(file, move_assignment) {
   EXPECT_TRUE(native_handle_is_valid(fst.native_handle()));
 }
 
-/// Tests file moving
-TEST(file, move) {
-  fs::path path;
-  entry::native_handle_type handle;
-
-  fs::path to = fs::path(BUILD_DIR) / "non-existing" / "parent";
-  {
-    file tmpfile = file();
-    path = tmpfile;
-    handle = tmpfile.native_handle();
-
-    tmpfile.move(to);
-  }
-
-  EXPECT_FALSE(fs::exists(path));
-  EXPECT_TRUE(fs::exists(to));
-  EXPECT_FALSE(native_handle_is_valid(handle));
-
-  fs::remove_all(fs::path(BUILD_DIR) / "non-existing");
-}
-
 /// Tests file swapping
 TEST(file, swap) {
   file fst = file();

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -403,9 +403,6 @@ TEST(file, move) {
     path = tmpfile;
     handle = tmpfile.native_handle();
 
-    std::cout << "from: " << tmpfile.path() << std::endl;
-    std::cout << "to: " << to << std::endl;
-
     tmpfile.move(to);
   }
 


### PR DESCRIPTION
- Fix a bug when moving an entry to itself caused a deletion of said entry
- Fix a bug when moving a directory to an existing file between filesystems would not throw an exception
- Fix a bug when move was constrained to regular files and directories only
- Fix a bug when an entry could be deleted even if it was not moved due to an error
- Add a lot of tests
- Explain the `entry::move` behaviour somewhat better