### PR TITLE
Do not use unity build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC std::filesystem)
 
 set_target_properties(${PROJECT_NAME}
   PROPERTIES EXPORT_NAME ${PROJECT_NAME}
-             UNITY_BUILD ON
              CXX_EXTENSIONS OFF
              CXX_VISIBILITY_PRESET hidden
              VISIBILITY_INLINES_HIDDEN ON

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,8 +10,7 @@ target_compile_definitions(${PROJECT_NAME}
 # On some platforms (e.g. Windows) CMake doesn't write load paths properly
 # This solution to put outputs in the same directory is good enough
 set_target_properties(${PROJECT_NAME}
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:tmp::tmp>
-             UNITY_BUILD ON)
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:tmp::tmp>)
 
 include(GoogleTest)
 gtest_discover_tests(${PROJECT_NAME} EXTRA_ARGS --gtest_color=yes)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ target_compile_definitions(${PROJECT_NAME}
 # On some platforms (e.g. Windows) CMake doesn't write load paths properly
 # This solution to put outputs in the same directory is good enough
 set_target_properties(${PROJECT_NAME}
-  PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:tmp::tmp>)
+  PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:tmp::tmp>
+             UNITY_BUILD ON)
 
 include(GoogleTest)
 gtest_discover_tests(${PROJECT_NAME} EXTRA_ARGS --gtest_color=yes)


### PR DESCRIPTION
According to [CMake documentation](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html#prop_tgt:UNITY_BUILD), UNITY_BUILD property should not be set by the project