### PR TITLE
Do not try to create entry again if failed

### DIFF
--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -39,10 +39,6 @@ create_directory(std::string_view label) {
 #ifdef _WIN32
   if (!CreateDirectoryW(path.c_str(), nullptr)) {
     DWORD err = GetLastError();
-    if (err == ERROR_ALREADY_EXISTS) {
-      return create_directory(label);
-    }
-
     ec = std::error_code(err, std::system_category());
   }
 #else

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -47,10 +47,6 @@ create_file(std::string_view label, std::string_view extension) {
 
   if (handle == INVALID_HANDLE_VALUE) {
     DWORD err = GetLastError();
-    if (err == ERROR_ALREADY_EXISTS) {
-      return create_file(label, extension);
-    }
-
     ec = std::error_code(err, std::system_category());
   }
 #else


### PR DESCRIPTION
Since we are using a GUID that is guaranteed not to overlap on the same machine, there is no point in checking if we have hit an existing file when trying to create a new one