### PR TITLE
Use a proper value for `invalid_handle`

### DIFF
--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -28,7 +28,7 @@ static_assert(std::is_same_v<HANDLE, void*>);
 
 /// Implementation-defined invalid handle to the entry
 #ifdef _WIN32
-const entry::native_handle_type invalid_handle = nullptr;
+const entry::native_handle_type invalid_handle = INVALID_HANDLE_VALUE;
 #else
 const entry::native_handle_type invalid_handle = -1;
 #endif


### PR DESCRIPTION
I forgot that `INVALID_HANDLE_VALUE` exists on Windows