### PR TITLE
Report errors in `file` input/output operations

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -74,14 +74,17 @@ public:
 
   /// Reads the entire contents of this file
   /// @returns A string with this file contents
+  /// @throws std::filesystem::filesystem_error if cannot read the file contents
   std::string read() const;
 
   /// Writes the given content to this file discarding any previous content
   /// @param content   A string to write to this file
+  /// @throws std::filesystem::filesystem_error if cannot write to the file
   void write(std::string_view content) const;
 
   /// Appends the given content to the end of this file
   /// @param content   A string to append to this file
+  /// @throws std::filesystem::filesystem_error if cannot append to the file
   void append(std::string_view content) const;
 
   /// Returns the input stream to this file

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -96,8 +96,8 @@ std::string file::read() const {
     stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
     return std::string(std::istreambuf_iterator(stream), {});
-  } catch (const std::ios::failure& error) {
-    throw fs::filesystem_error("Cannot read a temporary file", error.code());
+  } catch (const std::ios::failure& err) {
+    throw fs::filesystem_error("Cannot read a temporary file", err.code());
   }
 }
 
@@ -107,8 +107,8 @@ void file::write(std::string_view content) const {
     stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
     stream << content;
-  } catch (const std::ios::failure& error) {
-    throw fs::filesystem_error("Cannot write to a temporary file", error.code());
+  } catch (const std::ios::failure& err) {
+    throw fs::filesystem_error("Cannot write to a temporary file", err.code());
   }
 }
 
@@ -118,8 +118,8 @@ void file::append(std::string_view content) const {
     stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
     stream << content;
-  } catch (const std::ios::failure& error) {
-    throw fs::filesystem_error("Cannot write to a temporary file", error.code());
+  } catch (const std::ios::failure& err) {
+    throw fs::filesystem_error("Cannot write to a temporary file", err.code());
   }
 }
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -91,16 +91,36 @@ file file::copy(const fs::path& path, std::string_view label,
 }
 
 std::string file::read() const {
-  std::ifstream stream = input_stream();
-  return std::string(std::istreambuf_iterator<char>(stream), {});
+  try {
+    std::ifstream stream = input_stream();
+    stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+    return std::string(std::istreambuf_iterator(stream), {});
+  } catch (const std::ios::failure& error) {
+    throw fs::filesystem_error("Cannot read a temporary file", error.code());
+  }
 }
 
 void file::write(std::string_view content) const {
-  output_stream(std::ios::trunc) << content;
+  try {
+    std::ofstream stream = output_stream(std::ios::trunc);
+    stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+    stream << content;
+  } catch (const std::ios::failure& error) {
+    throw fs::filesystem_error("Cannot write to a temporary file", error.code());
+  }
 }
 
 void file::append(std::string_view content) const {
-  output_stream(std::ios::app) << content;
+  try {
+    std::ofstream stream = output_stream(std::ios::app);
+    stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+    stream << content;
+  } catch (const std::ios::failure& error) {
+    throw fs::filesystem_error("Cannot write to a temporary file", error.code());
+  }
 }
 
 std::ifstream file::input_stream() const {

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -130,6 +130,14 @@ TEST(file, read_text) {
   EXPECT_EQ(tmpfile.read(), "Hello,\nworld!\n");
 }
 
+/// Tests file reading error reporting
+TEST(file, read_error) {
+  file tmpfile = file();
+  fs::remove(tmpfile);
+
+  EXPECT_THROW(tmpfile.read(), fs::filesystem_error);
+}
+
 /// Tests binary file writing
 TEST(file, write_binary) {
   file tmpfile = file();
@@ -176,6 +184,15 @@ TEST(file, write_text) {
     EXPECT_EQ(content, "world!\n");
 #endif
   }
+}
+
+/// Tests file writing error reporting
+TEST(file, write_error) {
+  file tmpfile = file();
+  fs::permissions(tmpfile.path(), fs::perms::none);
+
+  EXPECT_THROW(tmpfile.write("Hello!"), fs::filesystem_error);
+  fs::permissions(tmpfile.path(), fs::perms::all);
 }
 
 /// Tests binary file appending
@@ -228,6 +245,15 @@ TEST(file, append_text) {
     EXPECT_EQ(content, "Hello,\n world!\n");
 #endif
   }
+}
+
+/// Tests file appending error reporting
+TEST(file, append_error) {
+  file tmpfile = file();
+  fs::permissions(tmpfile.path(), fs::perms::none);
+
+  EXPECT_THROW(tmpfile.append("world!"), fs::filesystem_error);
+  fs::permissions(tmpfile.path(), fs::perms::all);
 }
 
 /// Tests binary file reading from input_stream


### PR DESCRIPTION
Methods `file::read`, `file::write` and `file::append` did not report errors due to use of `<fstream>` C++ API

Reimplement these methods via system calls to actually check for system errors and throw proper `std::filesystem::filesystem_error`