### PR TITLE
Add `file::size` method

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-pro-type-member-init,
   -cppcoreguidelines-pro-type-vararg,
   -misc-const-correctness,
   -misc-include-cleaner,

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -80,8 +80,7 @@ public:
   /// Returns the size of this file
   /// @param[out] ec Parameter for error reporting
   /// @returns the size of this file, in bytes
-  /// @throws std::filesystem::filesystem_error if cannot get a file size
-  std::uintmax_t size(std::error_code& ec) const;
+  std::uintmax_t size(std::error_code& ec) const noexcept;
 
   /// Reads the entire contents of this file
   /// @returns A string with this file contents

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -72,6 +72,17 @@ public:
                    std::string_view label = "",
                    std::string_view extension = "");
 
+  /// Returns the size of this file
+  /// @returns the size of this file, in bytes
+  /// @throws std::filesystem::filesystem_error if cannot get a file size
+  std::uintmax_t size() const;
+
+  /// Returns the size of this file
+  /// @param[out] ec Parameter for error reporting
+  /// @returns the size of this file, in bytes
+  /// @throws std::filesystem::filesystem_error if cannot get a file size
+  std::uintmax_t size(std::error_code& ec) const;
+
   /// Reads the entire contents of this file
   /// @returns A string with this file contents
   /// @throws std::filesystem::filesystem_error if cannot read the file contents

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -145,13 +145,14 @@ std::uintmax_t file::size() const {
 
 std::uintmax_t file::size(std::error_code& ec) const noexcept {
 #ifdef _WIN32
-  LARGE_INTERGER size;
-  if (!GetFileSize(native_handle(), &size)) {
+  FILE_STANDARD_INFO info;
+  if (!GetFileInformationByHandleEx(native_handle(), FileStandardInfo, &info,
+                                    sizeof(info))) {
     ec = std::error_code(GetLastError(), std::system_category());
     return static_cast<std::uintmax_t>(-1);
   }
 
-  return size;
+  return info.EndOfFile.QuadPart;
 #else
   struct stat stat;
   if (fstat(native_handle(), &stat) == -1) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -143,7 +143,7 @@ std::uintmax_t file::size() const {
   return result;
 }
 
-std::uintmax_t file::size(std::error_code& ec) const {
+std::uintmax_t file::size(std::error_code& ec) const noexcept {
 #ifdef _WIN32
   LARGE_INTERGER size;
   if (!GetFileSize(native_handle(), &size)) {

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -110,6 +110,18 @@ TEST(file, copy_directory) {
   EXPECT_THROW(file::copy(tmpdir), fs::filesystem_error);
 }
 
+/// Tests getting a file size
+TEST(file, size) {
+  file empty = file();
+  EXPECT_EQ(empty.size(), 0);
+
+  std::string_view content = "Hello, world!";
+
+  file nonempty = file();
+  nonempty.write(content);
+  EXPECT_EQ(nonempty.size(), content.size());
+}
+
 /// Tests binary file reading
 TEST(file, read_binary) {
   file tmpfile = file();


### PR DESCRIPTION
Unlike `std::filesystem::file_size`, does not require existing path for the file