### PR TITLE
Fix the `file::copy` function

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -99,15 +99,27 @@ public:
                    std::error_code& ec);
 
   /// Creates a unique temporary copy from the given path
-  /// @param path      A path to make a temporary copy from
-  /// @param label     A label to attach to the temporary file path
-  /// @param extension An extension of the temporary file path
+  /// @param[in] path  A path to make a temporary copy from
+  /// @param[in] label A label to attach to the temporary file path
   /// @returns The new temporary file
   /// @throws std::filesystem::filesystem_error if given path is not a file
   /// @throws std::invalid_argument             if arguments are ill-formatted
   static file copy(const std::filesystem::path& path,
-                   std::string_view label = "",
-                   std::string_view extension = "");
+                   std::string_view label = "");
+
+  /// Creates a unique temporary copy from the given path
+  /// @param[in]  path A path to make a temporary copy from
+  /// @param[out] ec   Parameter for error reporting
+  /// @returns The new temporary file
+  static file copy(const std::filesystem::path& path, std::error_code& ec);
+
+  /// Creates a unique temporary copy from the given path
+  /// @param[in]  path  A path to make a temporary copy from
+  /// @param[in]  label A label to attach to the temporary file path
+  /// @param[out] ec    Parameter for error reporting
+  /// @returns The new temporary file
+  static file copy(const std::filesystem::path& path,
+                   std::string_view label, std::error_code& ec);
 
   /// Returns the size of this file
   /// @returns the size of this file, in bytes

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -118,8 +118,8 @@ public:
   /// @param[in]  label A label to attach to the temporary file path
   /// @param[out] ec    Parameter for error reporting
   /// @returns The new temporary file
-  static file copy(const std::filesystem::path& path,
-                   std::string_view label, std::error_code& ec);
+  static file copy(const std::filesystem::path& path, std::string_view label,
+                   std::error_code& ec);
 
   /// Returns the size of this file
   /// @returns the size of this file, in bytes

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -194,7 +194,7 @@ file file::copy(const fs::path& path, std::string_view label,
     return copy;
   }
 
-  native_handle_type handle = open(path.c_str(), ec);
+  native_handle_type handle = open(path.c_str(), ec);    // FIXME: close it
   if (ec) {
     return copy;
   }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -199,6 +199,7 @@ file file::copy(const fs::path& path, std::string_view label,
     return copy;
   }
 
+  // FIXME: can be optimized by block reading and writing
   std::string content = tmp::read(handle, ec);
   if (!ec) {
     tmp::write(copy.native_handle(), content, ec);


### PR DESCRIPTION
- Fixed a bug where a native handle of the copied file was pointing to the deleted file
- Removed an `extension` parameter since it can be obtained from the `path` parameter

Breaks library API