### PR TITLE
Do not open temporary directories

### DIFF
--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -17,19 +17,10 @@ namespace tmp {
 /// - the managing tmp::entry object is destroyed
 /// - the managing tmp::entry object is assigned another path via operator=
 ///
-/// Subclasses must provide a path and an open handle to the entry constructor;
-/// entry closes the handle before deleting the managed path
+/// Subclasses should provide a path to manage for this class;
+/// any opening or closing operations should be managed by subclasses
 class TMP_EXPORT entry {
 public:
-/// Implementation-defined handle type to the temporary entry
-#if defined(_WIN32)
-  using native_handle_type = void*;    // HANDLE
-#elif __has_include(<unistd.h>)
-  using native_handle_type = int;    // POSIX file descriptor
-#else
-#error "Target platform not supported"
-#endif
-
   /// Returns the managed path
   /// @returns The full path this entry manages
   operator const std::filesystem::path&() const noexcept;
@@ -37,10 +28,6 @@ public:
   /// Returns the managed path
   /// @returns The full path this entry manages
   const std::filesystem::path& path() const noexcept;
-
-  /// Returns an implementation-defined handle to this entry
-  /// @returns The underlying implementation-defined handle
-  native_handle_type native_handle() const noexcept;
 
   /// Moves the managed path recursively to a given target, releasing
   /// ownership of the managed path; behaves like `std::filesystem::rename`
@@ -58,7 +45,7 @@ public:
   /// @param[out] ec Parameter for error reporting
   void move(const std::filesystem::path& to, std::error_code& ec);
 
-  /// Deletes the managed path recursively and closes its handle
+  /// Deletes the managed path recursively
   virtual ~entry() noexcept;
 
   entry(const entry&) = delete;               ///< not CopyConstructible
@@ -72,14 +59,9 @@ public:
   bool operator>=(const entry& rhs) const noexcept;
 
 protected:
-  /// Creates a temporary entry which owns the given path and handle
-  /// @param[in] path   A path to manage
-  /// @param[in] handle An implementation-defined handle to this entry
-  explicit entry(std::filesystem::path path, native_handle_type handle);
-
-  /// Creates a temporary entry which owns the given path and handle
-  /// @param[in] handle A pair of a path and a handle to manage
-  explicit entry(std::pair<std::filesystem::path, native_handle_type> handle);
+  /// Creates a temporary entry which owns the given path
+  /// @param[in] path A path to manage
+  explicit entry(std::filesystem::path path) noexcept;
 
   entry(entry&&) noexcept;               ///< MoveConstructible
   entry& operator=(entry&&) noexcept;    ///< MoveAssignable
@@ -87,9 +69,6 @@ protected:
 private:
   /// The managed path
   std::filesystem::path pathobject;
-
-  /// Implementation-defined handle to this entry
-  native_handle_type handle;
 };
 }    // namespace tmp
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -43,6 +43,15 @@ namespace tmp {
 /// @endcode
 class TMP_EXPORT file : public entry {
 public:
+  /// Implementation-defined handle type to the temporary entry
+#if defined(_WIN32)
+  using native_handle_type = void*;    // HANDLE
+#elif __has_include(<unistd.h>)
+  using native_handle_type = int;    // POSIX file descriptor
+#else
+#error "Target platform not supported"
+#endif
+
   /// Creates a unique temporary file and opens it for reading and writing
   /// in binary mode
   /// @param[in] label     A label to attach to the temporary file path
@@ -108,6 +117,10 @@ public:
                    std::string_view label = "",
                    std::string_view extension = "");
 
+  /// Returns an implementation-defined handle to this entry
+  /// @returns The underlying implementation-defined handle
+  native_handle_type native_handle() const noexcept;
+
   /// Returns the size of this file
   /// @returns the size of this file, in bytes
   /// @throws std::filesystem::filesystem_error if cannot get a file size
@@ -168,6 +181,15 @@ public:
 private:
   /// Whether the managed file is opened in binary write mode
   bool binary;
+
+  /// Implementation-defined handle to this entry
+  native_handle_type handle;
+
+  /// Creates a unique temporary file
+  /// @param handle    A path to the created temporary file and its handle
+  /// @param binary    Whether the managed file is opened in binary write mode
+  file(std::pair<std::filesystem::path, native_handle_type> handle,
+       bool binary) noexcept TMP_NO_EXPORT;
 };
 }    // namespace tmp
 

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -144,7 +144,7 @@ create_file(std::string_view label, std::string_view extension,
                  nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
     ec = std::error_code(GetLastError(), std::system_category());
-    return std::pair<fs::path, entry::native_handle_type>();
+    return std::pair<fs::path, file::native_handle_type>();
   }
 #else
   // FIXME: `mkstemps` function is not a part of POSIX standard

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -1,6 +1,6 @@
 #include "create.hpp"
 
-#include <tmp/entry>
+#include <tmp/file>
 
 #include <filesystem>
 #include <stdexcept>
@@ -104,7 +104,7 @@ bool create_parent(const fs::path& path, std::error_code& ec) {
   return fs::create_directories(path.parent_path(), ec);
 }
 
-std::pair<fs::path, entry::native_handle_type>
+std::pair<fs::path, file::native_handle_type>
 create_file(std::string_view label, std::string_view extension) {
   validate_label(label);    // throws std::invalid_argument with a proper text
   validate_extension(extension);
@@ -119,12 +119,12 @@ create_file(std::string_view label, std::string_view extension) {
   return file;
 }
 
-std::pair<fs::path, entry::native_handle_type>
+std::pair<fs::path, file::native_handle_type>
 create_file(std::string_view label, std::string_view extension,
             std::error_code& ec) {
   if (!is_label_valid(label) || !is_extension_valid(extension)) {
     ec = std::make_error_code(std::errc::invalid_argument);
-    return std::pair<fs::path, entry::native_handle_type>();
+    return std::pair<fs::path, file::native_handle_type>();
   }
 
 #ifdef _WIN32
@@ -134,7 +134,7 @@ create_file(std::string_view label, std::string_view extension,
 #endif
   create_parent(path, ec);
   if (ec) {
-    return std::pair<fs::path, entry::native_handle_type>();
+    return std::pair<fs::path, file::native_handle_type>();
   }
 
 #ifdef _WIN32
@@ -151,7 +151,7 @@ create_file(std::string_view label, std::string_view extension,
   int handle = mkstemps(path.data(), static_cast<int>(extension.size()));
   if (handle == -1) {
     ec = std::error_code(errno, std::system_category());
-    return std::pair<fs::path, entry::native_handle_type>();
+    return std::pair<fs::path, file::native_handle_type>();
   }
 #endif
 
@@ -159,8 +159,7 @@ create_file(std::string_view label, std::string_view extension,
   return std::make_pair(path, handle);
 }
 
-std::pair<fs::path, entry::native_handle_type>
-create_directory(std::string_view label) {
+fs::path create_directory(std::string_view label) {
   validate_label(label);    // throws std::invalid_argument with a proper text
 
   std::error_code ec;
@@ -173,11 +172,10 @@ create_directory(std::string_view label) {
   return directory;
 }
 
-std::pair<fs::path, entry::native_handle_type>
-create_directory(std::string_view label, std::error_code& ec) {
+fs::path create_directory(std::string_view label, std::error_code& ec) {
   if (!is_label_valid(label)) {
     ec = std::make_error_code(std::errc::invalid_argument);
-    return std::pair<fs::path, entry::native_handle_type>();
+    return fs::path();
   }
 
 #ifdef _WIN32
@@ -187,31 +185,19 @@ create_directory(std::string_view label, std::error_code& ec) {
 #endif
   create_parent(path, ec);
   if (ec) {
-    return std::pair<fs::path, entry::native_handle_type>();
+    return fs::path();
   }
 
 #ifdef _WIN32
   if (!CreateDirectory(path.c_str(), nullptr)) {
     ec = std::error_code(GetLastError(), std::system_category());
-    return std::pair<fs::path, entry::native_handle_type>();
   }
 #else
   if (mkdtemp(path.data()) == nullptr) {
     ec = std::error_code(errno, std::system_category());
-    return std::pair<fs::path, entry::native_handle_type>();
   }
 #endif
 
-#ifdef _WIN32
-  HANDLE handle =
-      CreateFile(path.c_str(), GENERIC_READ | GENERIC_WRITE,
-                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                 nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
-#else
-  int handle = open(path.data(), O_DIRECTORY);
-#endif
-
-  // FIXME: last `open` call could fail, directory should be deleted
-  return std::make_pair(path, handle);
+  return path;
 }
 }    // namespace tmp

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -1,7 +1,7 @@
 #ifndef TMP_CREATE_H
 #define TMP_CREATE_H
 
-#include <tmp/entry>
+#include <tmp/file>
 
 #include <filesystem>
 #include <string_view>
@@ -24,7 +24,7 @@ bool create_parent(const fs::path& path, std::error_code& ec);
 /// @returns A path to the created temporary file and a handle to it
 /// @throws fs::filesystem_error  if cannot create a temporary file
 /// @throws std::invalid_argument if the label or extension is ill-formatted
-std::pair<fs::path, entry::native_handle_type>
+std::pair<fs::path, file::native_handle_type>
 create_file(std::string_view label, std::string_view extension);
 
 /// Creates a temporary file with the given label and extension in the system's
@@ -33,26 +33,24 @@ create_file(std::string_view label, std::string_view extension);
 /// @param[in]  extension An extension of the temporary file path
 /// @param[out] ec        Parameter for error reporting
 /// @returns A path to the created temporary file and a handle to it
-std::pair<fs::path, entry::native_handle_type>
+std::pair<fs::path, file::native_handle_type>
 create_file(std::string_view label, std::string_view extension,
             std::error_code& ec);
 
 /// Creates a temporary directory with the given label in the system's
-/// temporary directory, and opens it for searching
+/// temporary directory
 /// @param[in] label A label to attach to the temporary directory path
-/// @returns A path to the created temporary file and a handle to it
+/// @returns A path to the created temporary directory
 /// @throws fs::filesystem_error  if cannot create a temporary directory
 /// @throws std::invalid_argument if the label is ill-formatted
-std::pair<fs::path, entry::native_handle_type>
-create_directory(std::string_view label);
+fs::path create_directory(std::string_view label);
 
 /// Creates a temporary directory with the given label in the system's
-/// temporary directory, and opens it for searching
+/// temporary directory
 /// @param[in]  label A label to attach to the temporary directory path
 /// @param[out] ec    Parameter for error reporting
-/// @returns A path to the created temporary directory and a handle to it
-std::pair<fs::path, entry::native_handle_type>
-create_directory(std::string_view label, std::error_code& ec);
+/// @returns A path to the created temporary directory
+fs::path create_directory(std::string_view label, std::error_code& ec);
 }    // namespace tmp
 
 #endif    // TMP_CREATE_H

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 
 #ifdef _WIN32
 #define NOMINMAX
@@ -26,6 +27,21 @@
 namespace tmp {
 namespace {
 
+// Confirm that native_handle_type matches `TriviallyCopyable` named requirement
+static_assert(std::is_trivially_copyable_v<file::native_handle_type>);
+
+#ifdef _WIN32
+// Confirm that `HANDLE` is as implemented in `entry`
+static_assert(std::is_same_v<HANDLE, file::native_handle_type>);
+#endif
+
+/// Implementation-defined invalid handle to the file
+#ifdef _WIN32
+const file::native_handle_type invalid_handle = INVALID_HANDLE_VALUE;
+#else
+constexpr file::native_handle_type invalid_handle = -1;
+#endif
+
 /// Maximum number of bytes in one read/write operation
 constexpr std::string_view::size_type io_max = std::numeric_limits<int>::max();
 
@@ -38,7 +54,7 @@ constexpr std::size_t block_size = 4096;
 /// @param[out] ec     Parameter for error reporting
 /// @returns A string with read contents
 /// @throws std::bad_alloc if memory allocation fails
-std::string read(entry::native_handle_type handle, std::error_code& ec) {
+std::string read(file::native_handle_type handle, std::error_code& ec) {
   std::array buffer = std::array<std::string::value_type, block_size>();
   std::ostringstream content;
 
@@ -72,7 +88,7 @@ std::string read(entry::native_handle_type handle, std::error_code& ec) {
 /// @param[in]  handle  A native handle to write to
 /// @param[in]  content A string to write to this file
 /// @param[out] ec      Parameter for error reporting
-void write(entry::native_handle_type handle, std::string_view content,
+void write(file::native_handle_type handle, std::string_view content,
            std::error_code& ec) noexcept {
   do {
     int writable = static_cast<int>(std::min(content.size(), io_max));
@@ -105,24 +121,36 @@ void write(entry::native_handle_type handle, std::string_view content,
   }
 #endif
 }
+
+/// Closes the given entry, ignoring any errors
+/// @param[in] file The file to close
+void close(const file& file) noexcept {
+#ifdef _WIN32
+  CloseHandle(file.native_handle());
+#else
+  ::close(file.native_handle());
+#endif
+}
 }    // namespace
 
+file::file(std::pair<std::filesystem::path, file::native_handle_type> handle,
+           bool binary) noexcept
+    : entry(std::move(handle.first)),
+      binary(binary),
+      handle(handle.second) {}
+
 file::file(std::string_view label, std::string_view extension)
-    : entry(create_file(label, extension)),
-      binary(true) {}
+    : file(create_file(label, extension), /*binary=*/true) {}
 
 file::file(std::error_code& ec)
-    : entry(create_file("", "", ec)),
-      binary(true) {}
+    : file(create_file("", "", ec), /*binary=*/true) {}
 
 file::file(std::string_view label, std::error_code& ec)
-    : entry(create_file(label, "", ec)),
-      binary(true) {}
+    : file(create_file(label, "", ec), /*binary=*/true) {}
 
 file::file(std::string_view label, std::string_view extension,
            std::error_code& ec)
-    : entry(create_file(label, extension, ec)),
-      binary(true) {}
+    : file(create_file(label, extension, ec), /*binary=*/true) {}
 
 file file::text(std::string_view label, std::string_view extension) {
   file result = file(label, extension);
@@ -159,6 +187,10 @@ file file::copy(const fs::path& path, std::string_view label,
   }
 
   return tmpfile;
+}
+
+file::native_handle_type file::native_handle() const noexcept {
+  return handle;
 }
 
 std::uintmax_t file::size() const {
@@ -317,8 +349,26 @@ std::ofstream file::output_stream(std::ios::openmode mode) const {
   return std::ofstream(path(), mode);
 }
 
-file::~file() noexcept = default;
+file::~file() noexcept {
+  close(*this);
+}
 
-file::file(file&&) noexcept = default;
-file& file::operator=(file&& other) noexcept = default;
+file::file(file&& other) noexcept
+    : entry(std::move(other)),
+      binary(other.binary),
+      handle(other.handle) {
+  other.handle = invalid_handle;
+}
+
+file& file::operator=(file&& other) noexcept {
+  entry::operator=(std::move(other));
+  close(*this);
+
+  binary = other.binary;    // NOLINT(bugprone-use-after-move)
+  handle = other.handle;    // NOLINT(bugprone-use-after-move)
+
+  other.handle = invalid_handle;
+
+  return *this;
+}
 }    // namespace tmp

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -355,9 +355,10 @@ file::~file() noexcept {
 
 file::file(file&& other) noexcept
     : entry(std::move(other)),
-      binary(other.binary),
-      handle(other.handle) {
-  other.handle = invalid_handle;
+      binary(other.binary),    // NOLINT(bugprone-use-after-move)
+      handle(other.handle)     // NOLINT(bugprone-use-after-move)
+{
+  other.handle = invalid_handle;    // NOLINT(bugprone-use-after-move)
 }
 
 file& file::operator=(file&& other) noexcept {

--- a/tests/checks.hpp
+++ b/tests/checks.hpp
@@ -1,7 +1,7 @@
 #ifndef TMP_TESTS_CHECKS_H
 #define TMP_TESTS_CHECKS_H
 
-#include <tmp/entry>
+#include <tmp/file>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -14,7 +14,7 @@ namespace tmp {
 /// Checks if the given file handle is valid
 /// @param handle handle to check
 /// @returns whether the handle is valid
-inline bool native_handle_is_valid(entry::native_handle_type handle) {
+inline bool native_handle_is_valid(file::native_handle_type handle) {
 #ifdef _WIN32
   BY_HANDLE_FILE_INFORMATION info;
   return GetFileInformationByHandle(handle, &info);

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -1,8 +1,6 @@
 #include <tmp/directory>
 #include <tmp/file>
 
-#include "checks.hpp"
-
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -25,7 +23,6 @@ TEST(directory, create_with_label) {
   EXPECT_TRUE(fs::exists(tmpdir));
   EXPECT_TRUE(fs::is_directory(tmpdir));
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path() / LABEL));
-  EXPECT_TRUE(native_handle_is_valid(tmpdir.native_handle()));
 
   fs::perms permissions = fs::status(tmpdir).permissions();
 #ifdef _WIN32
@@ -45,7 +42,6 @@ TEST(directory, create_without_label) {
   EXPECT_TRUE(fs::exists(tmpdir));
   EXPECT_TRUE(fs::is_directory(tmpdir));
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
-  EXPECT_TRUE(native_handle_is_valid(tmpdir.native_handle()));
 }
 
 /// Tests multiple directories creation with the same label
@@ -121,15 +117,12 @@ TEST(directory, list) {
 /// Tests that destructor removes a directory
 TEST(directory, destructor) {
   fs::path path;
-  entry::native_handle_type handle;
   {
     directory tmpdir = directory();
     path = tmpdir;
-    handle = tmpdir.native_handle();
   }
 
   EXPECT_FALSE(fs::exists(path));
-  EXPECT_FALSE(native_handle_is_valid(handle));
 }
 
 /// Tests directory move constructor
@@ -141,7 +134,6 @@ TEST(directory, move_constructor) {
 
   EXPECT_FALSE(snd.path().empty());
   EXPECT_TRUE(fs::exists(snd));
-  EXPECT_TRUE(native_handle_is_valid(snd.native_handle()));
 }
 
 /// Tests directory move assignment operator
@@ -153,9 +145,6 @@ TEST(directory, move_assignment) {
     fs::path path1 = fst;
     fs::path path2 = snd;
 
-    entry::native_handle_type fst_handle = fst.native_handle();
-    entry::native_handle_type snd_handle = snd.native_handle();
-
     fst = std::move(snd);
 
     EXPECT_FALSE(fs::exists(path1));
@@ -163,13 +152,9 @@ TEST(directory, move_assignment) {
 
     EXPECT_TRUE(fs::exists(fst));
     EXPECT_TRUE(fs::equivalent(fst, path2));
-
-    EXPECT_FALSE(native_handle_is_valid(fst_handle));
-    EXPECT_TRUE(native_handle_is_valid(snd_handle));
   }
 
   EXPECT_FALSE(fst.path().empty());
-  EXPECT_TRUE(native_handle_is_valid(fst.native_handle()));
 }
 
 /// Tests directory swapping
@@ -179,15 +164,11 @@ TEST(directory, swap) {
 
   fs::path fst_path = fst.path();
   fs::path snd_path = snd.path();
-  entry::native_handle_type fst_handle = fst.native_handle();
-  entry::native_handle_type snd_handle = snd.native_handle();
 
   std::swap(fst, snd);
 
   EXPECT_EQ(fst.path(), snd_path);
   EXPECT_EQ(snd.path(), fst_path);
-  EXPECT_EQ(fst.native_handle(), snd_handle);
-  EXPECT_EQ(snd.native_handle(), fst_handle);
 }
 
 /// Tests directory hashing

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -36,7 +36,7 @@ directory test_directory() {
 /// Tests that moving a temporary file to itself does nothing
 TEST(entry, move_file_to_self) {
   fs::path path;
-  entry::native_handle_type handle;
+  file::native_handle_type handle;
 
   {
     file tmpfile = test_file();
@@ -61,7 +61,7 @@ TEST(entry, move_file_to_self) {
 /// Tests moving a temporary file to existing non-directory file
 TEST(entry, move_file_to_existing_file) {
   fs::path path;
-  entry::native_handle_type handle;
+  file::native_handle_type handle;
 
   fs::path to = fs::path(BUILD_DIR) / "move_file_to_existing_test";
   std::ofstream(to / "file") << "Goodbye, world!";
@@ -100,7 +100,7 @@ TEST(entry, move_file_to_existing_directory) {
 /// Tests moving a temporary file to a non-existing file
 TEST(entry, move_file_to_non_existing_file) {
   fs::path path;
-  entry::native_handle_type handle;
+  file::native_handle_type handle;
 
   fs::path parent = fs::path(BUILD_DIR) / "non-existing1";
   fs::path to = parent / "path";
@@ -139,18 +139,15 @@ TEST(entry, move_file_to_non_existing_directory) {
 /// Tests that moving a temporary directory to itself does nothing
 TEST(entry, move_directory_to_self) {
   fs::path path;
-  entry::native_handle_type handle;
 
   {
     directory tmpdir = test_directory();
     path = tmpdir;
-    handle = tmpdir.native_handle();
 
     tmpdir.move(tmpdir);
   }
 
   EXPECT_TRUE(fs::exists(path));
-  EXPECT_FALSE(native_handle_is_valid(handle));
 
   {
     auto stream = std::ifstream(path / "file");
@@ -164,7 +161,6 @@ TEST(entry, move_directory_to_self) {
 /// Tests moving a temporary directory to existing directory
 TEST(entry, move_directory_to_existing_directory) {
   fs::path path;
-  entry::native_handle_type handle;
 
   fs::path to = fs::path(BUILD_DIR) / "move_directory_to_existing_test";
   std::ofstream(to / "file2") << "Goodbye, world!";
@@ -172,14 +168,12 @@ TEST(entry, move_directory_to_existing_directory) {
   {
     directory tmpdir = test_directory();
     path = tmpdir;
-    handle = tmpdir.native_handle();
 
     tmpdir.move(to);
   }
 
   EXPECT_TRUE(fs::exists(to));
   EXPECT_FALSE(fs::exists(path));
-  EXPECT_FALSE(native_handle_is_valid(handle));
 
   {
     auto stream = std::ifstream(to / "file");
@@ -205,7 +199,6 @@ TEST(entry, move_directory_to_existing_file) {
 /// Tests moving a temporary directory to a non-existing path
 TEST(entry, move_directory_to_non_existing_path) {
   fs::path path;
-  entry::native_handle_type handle;
 
   fs::path parent = fs::path(BUILD_DIR) / "non-existing3";
   fs::path to = parent / "path";
@@ -213,14 +206,12 @@ TEST(entry, move_directory_to_non_existing_path) {
   {
     directory tmpdir = test_directory();
     path = tmpdir;
-    handle = tmpdir.native_handle();
 
     tmpdir.move(to);
   }
 
   EXPECT_TRUE(fs::exists(to));
   EXPECT_FALSE(fs::exists(path));
-  EXPECT_FALSE(native_handle_is_valid(handle));
 
   {
     auto stream = std::ifstream(to / "file");

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -488,7 +488,7 @@ TEST(file, output_stream_append_text_binary) {
 /// Tests that destructor removes a file
 TEST(file, destructor) {
   fs::path path;
-  entry::native_handle_type handle;
+  file::native_handle_type handle;
   {
     file tmpfile = file();
     path = tmpfile;
@@ -520,8 +520,8 @@ TEST(file, move_assignment) {
     fs::path path1 = fst;
     fs::path path2 = snd;
 
-    entry::native_handle_type fst_handle = fst.native_handle();
-    entry::native_handle_type snd_handle = snd.native_handle();
+    file::native_handle_type fst_handle = fst.native_handle();
+    file::native_handle_type snd_handle = snd.native_handle();
 
     fst = std::move(snd);
 
@@ -546,8 +546,8 @@ TEST(file, swap) {
 
   fs::path fst_path = fst.path();
   fs::path snd_path = snd.path();
-  entry::native_handle_type fst_handle = fst.native_handle();
-  entry::native_handle_type snd_handle = snd.native_handle();
+  file::native_handle_type fst_handle = fst.native_handle();
+  file::native_handle_type snd_handle = snd.native_handle();
 
   std::swap(fst, snd);
 


### PR DESCRIPTION
This essentially reverts https://github.com/bugdea1er/tmp/pull/114

Opening temporary directories doesn't help at all, since there is not much to do with its native handle, and even traversing the directory using the OS's native API reopens the directory

Also, defining and managing `native_handle` in `entry` limits the variety of types of handles: for instance, `file` could use corecrt on Windows and manage `int` instead of `HANDLE`
