### PR TITLE
Remove `directory::list` method

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -66,18 +66,6 @@ public:
   /// @returns The result of path concatenation
   std::filesystem::path operator/(std::string_view source) const;
 
-  /// Returns an iterator over the contents of this directory
-  /// @note The special pathnames `.` and `..` are skipped
-  /// @returns The iterator over this directory
-  /// @throws std::filesystem::filesystem_error on underlying OS API errors
-  std::filesystem::directory_iterator list() const;
-
-  /// Returns an iterator over the contents of this directory
-  /// @note The special pathnames `.` and `..` are skipped
-  /// @param[out] ec Parameter for error reporting
-  /// @returns The iterator over this directory
-  std::filesystem::directory_iterator list(std::error_code& ec) const;
-
   /// Deletes the managed directory recursively
   ~directory() noexcept override;
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -45,20 +45,6 @@ fs::path directory::operator/(std::string_view source) const {
   return path() / source;
 }
 
-fs::directory_iterator directory::list() const {
-  std::error_code ec;
-  fs::directory_iterator iterator = list(ec);
-  if (ec) {
-    throw fs::filesystem_error("Cannot list a temporary directory", path(), ec);
-  }
-
-  return iterator;
-}
-
-fs::directory_iterator directory::list(std::error_code& ec) const {
-  return fs::directory_iterator(path(), ec);
-}
-
 directory::~directory() noexcept = default;
 
 directory::directory(directory&&) noexcept = default;

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -97,23 +97,6 @@ TEST(directory, subpath) {
   EXPECT_TRUE(fs::equivalent(tmpdir, child.parent_path()));
 }
 
-/// Tests directory listing
-TEST(directory, list) {
-  directory tmpdir = directory();
-  std::ofstream(tmpdir / "file1") << "Hello, world!";
-  std::ofstream(tmpdir / "file2") << "Hello, world!";
-
-  fs::create_directory(tmpdir / "subdir");
-  std::ofstream(tmpdir / "subdir" / "file") << "Hello, world!";
-
-  std::set entries = std::set<fs::path>();
-  for (const auto& entry : tmpdir.list()) {
-    entries.insert(fs::relative(entry, tmpdir));
-  }
-
-  EXPECT_EQ(entries, std::set<fs::path>({"file1", "file2", "subdir"}));
-}
-
 /// Tests that destructor removes a directory
 TEST(directory, destructor) {
   fs::path path;


### PR DESCRIPTION
`directory::list` does not add anything new compared to the standard:

```cpp
std::filesystem::directory_iterator(tmpdir);
std::filesystem::recursive_directory_iterator(tmpdir);
```

Since native OS directory APIs behave differently and there is no standard way to iterate over opened directories in C/C++, `directory::list` cannot be optimized and is therefore useless