### PR TITLE
Do not create target parent when moving a temporary entry

### DIFF
--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -32,7 +32,6 @@ public:
   /// Moves the managed path recursively to a given target, releasing
   /// ownership of the managed path; behaves like `std::filesystem::rename`
   /// even when moving between filesystems
-  /// @note The target path parent is created when this function is called
   /// @param[in] to A path to the target file or directory
   /// @throws std::filesystem::filesystem_error if cannot move the owned path
   void move(const std::filesystem::path& to);
@@ -40,7 +39,6 @@ public:
   /// Moves the managed path recursively to a given target, releasing
   /// ownership of the managed path; behaves like `std::filesystem::rename`
   /// even when moving between filesystems
-  /// @note The target path parent is created when this function is called
   /// @param[in]  to A path to the target file or directory
   /// @param[out] ec Parameter for error reporting
   void move(const std::filesystem::path& to, std::error_code& ec);

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -52,11 +52,6 @@ void move(const fs::path& from, const fs::path& to, std::error_code& ec) {
     }
   }
 
-  create_parent(to, ec);
-  if (ec) {
-    return;
-  }
-
   bool copying = false;
 
 #ifdef _WIN32

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -97,35 +97,6 @@ TEST(entry, move_file_to_existing_directory) {
   fs::remove_all(directory);
 }
 
-/// Tests moving a temporary file to a non-existing file
-TEST(entry, move_file_to_non_existing_file) {
-  fs::path path;
-  file::native_handle_type handle;
-
-  fs::path parent = fs::path(BUILD_DIR) / "non-existing1";
-  fs::path to = parent / "path";
-
-  {
-    file tmpfile = test_file();
-    path = tmpfile;
-    handle = tmpfile.native_handle();
-
-    tmpfile.move(to);
-  }
-
-  EXPECT_TRUE(fs::exists(to));
-  EXPECT_FALSE(fs::exists(path));
-  EXPECT_FALSE(native_handle_is_valid(handle));
-
-  {
-    auto stream = std::ifstream(to);
-    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-    EXPECT_EQ(content, "Hello, world!");
-  }
-
-  fs::remove_all(parent);
-}
-
 /// Tests moving a temporary file to a non-existing directory
 TEST(entry, move_file_to_non_existing_directory) {
   fs::path parent = fs::path(BUILD_DIR) / "non-existing2";
@@ -194,31 +165,5 @@ TEST(entry, move_directory_to_existing_file) {
   EXPECT_THROW(test_directory().move(to), fs::filesystem_error);
 
   fs::remove_all(to);
-}
-
-/// Tests moving a temporary directory to a non-existing path
-TEST(entry, move_directory_to_non_existing_path) {
-  fs::path path;
-
-  fs::path parent = fs::path(BUILD_DIR) / "non-existing3";
-  fs::path to = parent / "path";
-
-  {
-    directory tmpdir = test_directory();
-    path = tmpdir;
-
-    tmpdir.move(to);
-  }
-
-  EXPECT_TRUE(fs::exists(to));
-  EXPECT_FALSE(fs::exists(path));
-
-  {
-    auto stream = std::ifstream(to / "file");
-    auto content = std::string(std::istreambuf_iterator<char>(stream), {});
-    EXPECT_EQ(content, "Hello, world!");
-  }
-
-  fs::remove_all(parent);
 }
 }    // namespace tmp


### PR DESCRIPTION
This mimics the `std::filesystem::rename` closer