### PR TITLE
Move `move` from `entry`

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -66,6 +66,20 @@ public:
   /// @returns The result of path concatenation
   std::filesystem::path operator/(std::string_view source) const;
 
+  /// Moves the managed directory recursively to a given target, releasing
+  /// ownership of the managed directory; behaves like `std::filesystem::rename`
+  /// even when moving between filesystems
+  /// @param[in] to A path to the target directory
+  /// @throws std::filesystem::filesystem_error if cannot move the owned path
+  void move(const std::filesystem::path& to);
+
+  /// Moves the managed directory recursively to a given target, releasing
+  /// ownership of the managed directory; behaves like `std::filesystem::rename`
+  /// even when moving between filesystems
+  /// @param[in]  to A path to the target directory
+  /// @param[out] ec Parameter for error reporting
+  void move(const std::filesystem::path& to, std::error_code& ec);
+
   /// Deletes the managed directory recursively
   ~directory() noexcept override;
 

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -29,20 +29,6 @@ public:
   /// @returns The full path this entry manages
   const std::filesystem::path& path() const noexcept;
 
-  /// Moves the managed path recursively to a given target, releasing
-  /// ownership of the managed path; behaves like `std::filesystem::rename`
-  /// even when moving between filesystems
-  /// @param[in] to A path to the target file or directory
-  /// @throws std::filesystem::filesystem_error if cannot move the owned path
-  void move(const std::filesystem::path& to);
-
-  /// Moves the managed path recursively to a given target, releasing
-  /// ownership of the managed path; behaves like `std::filesystem::rename`
-  /// even when moving between filesystems
-  /// @param[in]  to A path to the target file or directory
-  /// @param[out] ec Parameter for error reporting
-  void move(const std::filesystem::path& to, std::error_code& ec);
-
   /// Deletes the managed path recursively
   virtual ~entry() noexcept;
 
@@ -60,6 +46,9 @@ protected:
   /// Creates a temporary entry which owns the given path
   /// @param[in] path A path to manage
   explicit entry(std::filesystem::path path) noexcept;
+
+  /// Clears the stored pathname
+  void clear() noexcept;
 
   entry(entry&&) noexcept;               ///< MoveConstructible
   entry& operator=(entry&&) noexcept;    ///< MoveAssignable

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -170,6 +170,20 @@ public:
   /// @returns An opened stream for output operations
   std::ofstream output_stream(std::ios::openmode mode = std::ios::trunc) const;
 
+  /// Moves the managed file to a given target, releasing
+  /// ownership of the managed file; behaves like `std::filesystem::rename`
+  /// even when moving between filesystems
+  /// @param[in] to A path to the target file
+  /// @throws std::filesystem::filesystem_error if cannot move the owned file
+  void move(const std::filesystem::path& to);
+
+  /// Moves the managed file recursively to a given target, releasing
+  /// ownership of the managed file; behaves like `std::filesystem::rename`
+  /// even when moving between filesystems
+  /// @param[in]  to A path to the target file
+  /// @param[out] ec Parameter for error reporting
+  void move(const std::filesystem::path& to, std::error_code& ec);
+
   /// Deletes the managed file
   ~file() noexcept override;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Filesystem REQUIRED)
 include(GenerateExportHeader)
 
-add_library(${PROJECT_NAME} create.cpp entry.cpp file.cpp directory.cpp)
+add_library(${PROJECT_NAME} create.cpp entry.cpp file.cpp directory.cpp move.cpp)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_link_libraries(${PROJECT_NAME} PUBLIC std::filesystem)
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -2,6 +2,7 @@
 #include <tmp/entry>
 
 #include "create.hpp"
+#include "move.hpp"
 
 #include <filesystem>
 #include <string_view>
@@ -43,6 +44,23 @@ directory directory::copy(const fs::path& path, std::string_view label) {
 
 fs::path directory::operator/(std::string_view source) const {
   return path() / source;
+}
+
+void directory::move(const fs::path& to) {
+  std::error_code ec;
+  move(to, ec);
+
+  if (ec) {
+    throw fs::filesystem_error("Cannot move a temporary directory", path(), to,
+                               ec);
+  }
+}
+
+void directory::move(const fs::path& to, std::error_code& ec) {
+  tmp::move(*this, to, ec);
+  if (!ec) {
+    clear();
+  }
 }
 
 directory::~directory() noexcept = default;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -1,85 +1,13 @@
 #include <tmp/entry>
 
 #include "create.hpp"
+#include "move.hpp"
 
 #include <cstddef>
 #include <filesystem>
-#include <new>
 #include <system_error>
 
 namespace tmp {
-namespace {
-
-/// Options for recursive overwriting copying
-constexpr fs::copy_options copy_options =
-    fs::copy_options::recursive | fs::copy_options::overwrite_existing;
-
-/// Deletes the given path recursively, ignoring any errors
-/// @param[in] path The path to delete
-void remove(const fs::path& path) noexcept {
-  if (!path.empty()) {
-    try {
-      std::error_code ec;
-      fs::remove_all(path, ec);
-
-      fs::path parent = path.parent_path();
-      if (!fs::equivalent(parent, fs::temp_directory_path(), ec)) {
-        fs::remove(parent, ec);
-      }
-    } catch (const std::bad_alloc& ex) {
-      static_cast<void>(ex);
-    }
-  }
-}
-
-/// Moves the filesystem object as if by `std::filesystem::rename`
-/// even when moving between filesystems
-/// @param[in]  from The path to move
-/// @param[in]  to   A path to the target file or directory
-/// @param[out] ec   Parameter for error reporting
-/// @throws std::bad_alloc if memory allocation fails
-void move(const fs::path& from, const fs::path& to, std::error_code& ec) {
-  // FIXME: `fs::is_directory can fail here`
-  if (fs::exists(to)) {
-    if (!fs::is_directory(from) && fs::is_directory(to)) {
-      ec = std::make_error_code(std::errc::is_a_directory);
-      return;
-    }
-
-    if (fs::is_directory(from) && !fs::is_directory(to)) {
-      ec = std::make_error_code(std::errc::not_a_directory);
-      return;
-    }
-  }
-
-  bool copying = false;
-
-#ifdef _WIN32
-  // On Windows, the underlying `MoveFileExW` fails when moving a directory
-  // between drives; in that case we copy the directory manually
-  copying = fs::is_directory(from) && from.root_name() != to.root_name();
-  if (copying) {
-    fs::copy(from, to, copy_options, ec);
-  } else {
-    fs::rename(from, to, ec);
-  }
-#else
-  // On POSIX-compliant systems, the underlying `rename` function may return
-  // `EXDEV` if the implementation does not support links between file systems;
-  // so we try to rename the file, and if we fail with `EXDEV`, move it manually
-  fs::rename(from, to, ec);
-  copying = ec == std::errc::cross_device_link;
-  if (copying) {
-    fs::remove_all(to);
-    fs::copy(from, to, copy_options, ec);
-  }
-#endif
-
-  if (!ec && copying) {
-    tmp::remove(from);
-  }
-}
-}    // namespace
 
 entry::entry(fs::path path) noexcept
     : pathobject(std::move(path)) {}
@@ -110,22 +38,6 @@ const fs::path& entry::path() const noexcept {
   return *this;
 }
 
-void entry::move(const fs::path& to) {
-  std::error_code ec;
-  move(to, ec);
-
-  if (ec) {
-    throw fs::filesystem_error("Cannot move a temporary entry", path(), to, ec);
-  }
-}
-
-void entry::move(const fs::path& to, std::error_code& ec) {
-  tmp::move(*this, to, ec);
-  if (!ec) {
-    pathobject.clear();
-  }
-}
-
 bool entry::operator==(const entry& rhs) const noexcept {
   return path() == rhs.path();
 }
@@ -148,6 +60,10 @@ bool entry::operator>(const entry& rhs) const noexcept {
 
 bool entry::operator>=(const entry& rhs) const noexcept {
   return path() >= rhs.path();
+}
+
+void entry::clear() noexcept {
+  pathobject.clear();
 }
 }    // namespace tmp
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -2,6 +2,7 @@
 #include <tmp/file>
 
 #include "create.hpp"
+#include "move.hpp"
 
 #include <array>
 #include <cstddef>
@@ -347,6 +348,22 @@ std::ifstream file::input_stream() const {
 std::ofstream file::output_stream(std::ios::openmode mode) const {
   binary ? mode |= std::ios::binary : mode &= ~std::ios::binary;
   return std::ofstream(path(), mode);
+}
+
+void file::move(const fs::path& to) {
+  std::error_code ec;
+  move(to, ec);
+
+  if (ec) {
+    throw fs::filesystem_error("Cannot move a temporary file", path(), to, ec);
+  }
+}
+
+void file::move(const fs::path& to, std::error_code& ec) {
+  tmp::move(*this, to, ec);
+  if (!ec) {
+    clear();
+  }
 }
 
 file::~file() noexcept {

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1,0 +1,72 @@
+#include "move.hpp"
+
+#include <filesystem>
+#include <new>
+#include <system_error>
+
+namespace tmp {
+namespace {
+
+/// Options for recursive overwriting copying
+constexpr fs::copy_options copy_options =
+    fs::copy_options::recursive | fs::copy_options::overwrite_existing;
+}    // namespace
+
+void move(const fs::path& from, const fs::path& to, std::error_code& ec) {
+  // FIXME: `fs::is_directory can fail here`
+  if (fs::exists(to)) {
+    if (!fs::is_directory(from) && fs::is_directory(to)) {
+      ec = std::make_error_code(std::errc::is_a_directory);
+      return;
+    }
+
+    if (fs::is_directory(from) && !fs::is_directory(to)) {
+      ec = std::make_error_code(std::errc::not_a_directory);
+      return;
+    }
+  }
+
+  bool copying = false;
+
+#ifdef _WIN32
+  // On Windows, the underlying `MoveFileExW` fails when moving a directory
+  // between drives; in that case we copy the directory manually
+  copying = fs::is_directory(from) && from.root_name() != to.root_name();
+  if (copying) {
+    fs::copy(from, to, copy_options, ec);
+  } else {
+    fs::rename(from, to, ec);
+  }
+#else
+  // On POSIX-compliant systems, the underlying `rename` function may return
+  // `EXDEV` if the implementation does not support links between file systems;
+  // so we try to rename the file, and if we fail with `EXDEV`, move it manually
+  fs::rename(from, to, ec);
+  copying = ec == std::errc::cross_device_link;
+  if (copying) {
+    fs::remove_all(to);
+    fs::copy(from, to, copy_options, ec);
+  }
+#endif
+
+  if (!ec && copying) {
+    tmp::remove(from);
+  }
+}
+
+void remove(const fs::path& path) noexcept {
+  if (!path.empty()) {
+    try {
+      std::error_code ec;
+      fs::remove_all(path, ec);
+
+      fs::path parent = path.parent_path();
+      if (!fs::equivalent(parent, fs::temp_directory_path(), ec)) {
+        fs::remove(parent, ec);
+      }
+    } catch (const std::bad_alloc& ex) {
+      static_cast<void>(ex);
+    }
+  }
+}
+}    // namespace tmp

--- a/src/move.hpp
+++ b/src/move.hpp
@@ -1,0 +1,23 @@
+#ifndef TMP_MOVE_H
+#define TMP_MOVE_H
+
+#include <filesystem>
+#include <system_error>
+
+namespace tmp {
+namespace fs = std::filesystem;
+
+/// Moves the filesystem object as if by `std::filesystem::rename`
+/// even when moving between filesystems
+/// @param[in]  from The path to move
+/// @param[in]  to   A path to the target file or directory
+/// @param[out] ec   Parameter for error reporting
+/// @throws std::bad_alloc if memory allocation fails
+void move(const fs::path& from, const fs::path& to, std::error_code& ec);
+
+/// Deletes the given path recursively, ignoring any errors
+/// @param[in] path The path to delete
+void remove(const fs::path& path) noexcept;
+}    // namespace tmp
+
+#endif    // TMP_MOVE_H

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -6,7 +6,6 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
-#include <set>
 #include <stdexcept>
 #include <utility>
 

--- a/tests/entry.cpp
+++ b/tests/entry.cpp
@@ -1,5 +1,4 @@
 #include <tmp/directory>
-#include <tmp/entry>
 #include <tmp/file>
 
 #include "checks.hpp"

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -13,6 +13,12 @@
 #include <stdexcept>
 #include <utility>
 
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <fcntl.h>
+#endif
+
 namespace tmp {
 namespace {
 


### PR DESCRIPTION
Abstract `tmp::entry` should not provide a `move` method because:
- the temporary entry may need to be closed before moving
- moving the temporary entry may not make sense at all, e.g. for sockets