### PR TITLE
Make `create` accept `openmode` as a parameter

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -136,13 +136,14 @@ template<typename Handle> void close(Handle handle) noexcept {
 }
 }    // namespace
 
-std::pair<fs::path, std::filebuf>
-create_file(std::string_view label, std::string_view extension, bool binary) {
+std::pair<fs::path, std::filebuf> create_file(std::string_view label,
+                                              std::string_view extension,
+                                              std::ios::openmode mode) {
   validate_label(label);    // throws std::invalid_argument with a proper text
   validate_extension(extension);
 
   std::error_code ec;
-  auto file = create_file(label, extension, binary, ec);
+  auto file = create_file(label, extension, mode, ec);
 
   if (ec) {
     throw fs::filesystem_error("Cannot create a temporary file", ec);
@@ -153,7 +154,7 @@ create_file(std::string_view label, std::string_view extension, bool binary) {
 
 std::pair<fs::path, std::filebuf> create_file(std::string_view label,
                                               std::string_view extension,
-                                              bool binary,
+                                              std::ios::openmode mode,
                                               std::error_code& ec) {
   if (!is_label_valid(label) || !is_extension_valid(extension)) {
     ec = std::make_error_code(std::errc::invalid_argument);
@@ -189,9 +190,6 @@ std::pair<fs::path, std::filebuf> create_file(std::string_view label,
 #endif
 
   scope_guard on_exit = scope_guard([&] { close(handle); });
-
-  std::ios::openmode mode = binary ? std::ios::binary : std::ios::openmode();
-  mode |= std::ios::in | std::ios::out;
 
   std::filebuf filebuf;
   filebuf.open(path, mode);

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <ios>
 #include <string_view>
 #include <system_error>
 #include <utility>
@@ -14,23 +15,25 @@ namespace fs = std::filesystem;
 /// temporary directory, and opens it for reading and writing
 /// @param[in] label     A label to attach to the temporary file path
 /// @param[in] extension An extension of the temporary file path
-/// @param[in] binary    Whether to open the file in binary mode
+/// @param[in] mode      Specifies stream open mode
 /// @returns A path to the created temporary file and a handle to it
 /// @throws fs::filesystem_error  if cannot create a temporary file
 /// @throws std::invalid_argument if the label or extension is ill-formatted
-std::pair<fs::path, std::filebuf>
-create_file(std::string_view label, std::string_view extension, bool binary);
+std::pair<fs::path, std::filebuf> create_file(std::string_view label,
+                                              std::string_view extension,
+                                              std::ios::openmode mode);
 
 /// Creates a temporary file with the given label and extension in the system's
 /// temporary directory, and opens it for reading and writing
 /// @param[in]  label     A label to attach to the temporary file path
 /// @param[in]  extension An extension of the temporary file path
-/// @param[in]  binary    Whether to open the file in binary mode
+/// @param[in]  binary    Specifies stream open mode
 /// @param[out] ec        Parameter for error reporting
 /// @returns A path to the created temporary file and a handle to it
 std::pair<fs::path, std::filebuf> create_file(std::string_view label,
                                               std::string_view extension,
-                                              bool binary, std::error_code& ec);
+                                              std::ios::openmode mode,
+                                              std::error_code& ec);
 
 /// Creates a temporary directory with the given label in the system's
 /// temporary directory

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -5,12 +5,21 @@
 #include "move.hpp"
 
 #include <filesystem>
+#include <ios>
 #include <istream>
 #include <string_view>
 #include <system_error>
 #include <utility>
 
 namespace tmp {
+namespace {
+
+/// A mode to open a text file with
+constexpr std::ios::openmode text_mode = std::ios::in | std::ios::out;
+
+/// A mode to open a binary file with
+constexpr std::ios::openmode binary_mode = std::ios::binary | text_mode;
+}    // namespace
 
 file::file(std::pair<std::filesystem::path, std::filebuf> handle) noexcept
     : entry(std::move(handle.first)),
@@ -18,20 +27,20 @@ file::file(std::pair<std::filesystem::path, std::filebuf> handle) noexcept
       filebuf(std::move(handle.second)) {}
 
 file::file(std::string_view label, std::string_view extension)
-    : file(create_file(label, extension, /*binary=*/true)) {}
+    : file(create_file(label, extension, binary_mode)) {}
 
 file::file(std::error_code& ec)
-    : file(create_file("", "", /*binary=*/true, ec)) {}
+    : file(create_file("", "", binary_mode, ec)) {}
 
 file::file(std::string_view label, std::error_code& ec)
-    : file(create_file(label, "", /*binary=*/true, ec)) {}
+    : file(create_file(label, "", binary_mode, ec)) {}
 
 file::file(std::string_view label, std::string_view extension,
            std::error_code& ec)
-    : file(create_file(label, extension, /*binary=*/true, ec)) {}
+    : file(create_file(label, extension, binary_mode, ec)) {}
 
 file file::text(std::string_view label, std::string_view extension) {
-  return file(create_file(label, extension, /*binary=*/false));
+  return file(create_file(label, extension, text_mode));
 }
 
 file file::text(std::error_code& ec) {
@@ -44,7 +53,7 @@ file file::text(std::string_view label, std::error_code& ec) {
 
 file file::text(std::string_view label, std::string_view extension,
                 std::error_code& ec) {
-  return file(create_file(label, extension, /*binary=*/false, ec));
+  return file(create_file(label, extension, text_mode, ec));
 }
 
 file file::copy(const fs::path& path, std::string_view label,


### PR DESCRIPTION
Follow up pull requests will accept `openmode` in `file` constructors