### PR TITLE
Remove all `error_code` overloads

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -6,7 +6,6 @@
 
 #include <filesystem>
 #include <string_view>
-#include <system_error>
 
 namespace tmp {
 
@@ -43,15 +42,6 @@ public:
   /// @throws std::invalid_argument             if the label is ill-formatted
   explicit directory(std::string_view label = "");
 
-  /// Creates a unique temporary directory
-  /// @param[out] ec Parameter for error reporting
-  explicit directory(std::error_code& ec);
-
-  /// Creates a unique temporary directory
-  /// @param[in]  label A label to attach to the temporary directory path
-  /// @param[out] ec    Parameter for error reporting
-  explicit directory(std::string_view label, std::error_code& ec);
-
   /// Creates a unique temporary copy recursively from the given path
   /// @param path      A path to make a temporary copy from
   /// @param label     A label to attach to the temporary directory path
@@ -72,13 +62,6 @@ public:
   /// @param[in] to A path to the target directory
   /// @throws std::filesystem::filesystem_error if cannot move the owned path
   void move(const std::filesystem::path& to);
-
-  /// Moves the managed directory recursively to a given target, releasing
-  /// ownership of the managed directory; behaves like `std::filesystem::rename`
-  /// even when moving between filesystems
-  /// @param[in]  to A path to the target directory
-  /// @param[out] ec Parameter for error reporting
-  void move(const std::filesystem::path& to, std::error_code& ec);
 
   /// Deletes the managed directory recursively
   ~directory() noexcept override;

--- a/include/tmp/entry
+++ b/include/tmp/entry
@@ -5,8 +5,6 @@
 
 #include <cstddef>
 #include <filesystem>
-#include <system_error>
-#include <utility>
 
 namespace tmp {
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -48,24 +48,6 @@ public:
   explicit file(std::string_view label = "", std::string_view extension = "");
 
   /// Creates a unique temporary file and opens it for reading and writing
-  /// in binary mode
-  /// @param[out] ec Parameter for error reporting
-  explicit file(std::error_code& ec);
-
-  /// Creates a unique temporary file and opens it for reading and writing
-  /// in binary mode
-  /// @param[in]  label A label to attach to the temporary file path
-  /// @param[out] ec    Parameter for error reporting
-  file(std::string_view label, std::error_code& ec);
-
-  /// Creates a unique temporary file and opens it for reading and writing
-  /// in binary mode
-  /// @param[in]  label     A label to attach to the temporary file path
-  /// @param[in]  extension An extension of the temporary file path
-  /// @param[out] ec        Parameter for error reporting
-  file(std::string_view label, std::string_view extension, std::error_code& ec);
-
-  /// Creates a unique temporary file and opens it for reading and writing
   /// in text mode
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path
@@ -73,25 +55,6 @@ public:
   /// @throws std::invalid_argument             if arguments are ill-formatted
   static file text(std::string_view label = "",
                    std::string_view extension = "");
-
-  /// Creates a unique temporary file and opens it for reading and writing
-  /// in text mode
-  /// @param[out] ec Parameter for error reporting
-  static file text(std::error_code& ec);
-
-  /// Creates a unique temporary file and opens it for reading and writing
-  /// in text mode
-  /// @param[in]  label A label to attach to the temporary file path
-  /// @param[out] ec    Parameter for error reporting
-  static file text(std::string_view label, std::error_code& ec);
-
-  /// Creates a unique temporary file and opens it for reading and writing
-  /// in text mode
-  /// @param[in]  label     A label to attach to the temporary file path
-  /// @param[in]  extension An extension of the temporary file path
-  /// @param[out] ec        Parameter for error reporting
-  static file text(std::string_view label, std::string_view extension,
-                   std::error_code& ec);
 
   /// Creates a unique temporary copy from the given path
   /// @param path      A path to make a temporary copy from
@@ -110,13 +73,6 @@ public:
   /// @param[in] to A path to the target file
   /// @throws std::filesystem::filesystem_error if cannot move the owned file
   void move(const std::filesystem::path& to);
-
-  /// Moves the managed file recursively to a given target, releasing
-  /// ownership of the managed file; behaves like `std::filesystem::rename`
-  /// even when moving between filesystems
-  /// @param[in]  to A path to the target file
-  /// @param[out] ec Parameter for error reporting
-  void move(const std::filesystem::path& to, std::error_code& ec);
 
   /// Deletes and closes the managed file
   ~file() noexcept override;

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -19,12 +19,6 @@ constexpr fs::copy_options copy_options =
 directory::directory(std::string_view label)
     : entry(create_directory(label)) {}
 
-directory::directory(std::error_code& ec)
-    : entry(create_directory("", ec)) {}
-
-directory::directory(std::string_view label, std::error_code& ec)
-    : entry(create_directory(label, ec)) {}
-
 directory directory::copy(const fs::path& path, std::string_view label) {
   directory tmpdir = directory(label);
 
@@ -48,19 +42,14 @@ fs::path directory::operator/(std::string_view source) const {
 
 void directory::move(const fs::path& to) {
   std::error_code ec;
-  move(to, ec);
+  tmp::move(*this, to, ec);
 
   if (ec) {
     throw fs::filesystem_error("Cannot move a temporary directory", path(), to,
                                ec);
   }
-}
 
-void directory::move(const fs::path& to, std::error_code& ec) {
-  tmp::move(*this, to, ec);
-  if (!ec) {
-    clear();
-  }
+  clear();
 }
 
 directory::~directory() noexcept = default;

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <filesystem>
-#include <system_error>
 
 namespace tmp {
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -29,31 +29,8 @@ file::file(std::pair<std::filesystem::path, std::filebuf> handle) noexcept
 file::file(std::string_view label, std::string_view extension)
     : file(create_file(label, extension, binary_mode)) {}
 
-file::file(std::error_code& ec)
-    : file(create_file("", "", binary_mode, ec)) {}
-
-file::file(std::string_view label, std::error_code& ec)
-    : file(create_file(label, "", binary_mode, ec)) {}
-
-file::file(std::string_view label, std::string_view extension,
-           std::error_code& ec)
-    : file(create_file(label, extension, binary_mode, ec)) {}
-
 file file::text(std::string_view label, std::string_view extension) {
   return file(create_file(label, extension, text_mode));
-}
-
-file file::text(std::error_code& ec) {
-  return text("", ec);
-}
-
-file file::text(std::string_view label, std::error_code& ec) {
-  return text(label, "", ec);
-}
-
-file file::text(std::string_view label, std::string_view extension,
-                std::error_code& ec) {
-  return file(create_file(label, extension, text_mode, ec));
 }
 
 file file::copy(const fs::path& path, std::string_view label,
@@ -71,20 +48,16 @@ file file::copy(const fs::path& path, std::string_view label,
 }
 
 void file::move(const fs::path& to) {
+  filebuf.close();
+
   std::error_code ec;
-  move(to, ec);
+  tmp::move(*this, to, ec);
 
   if (ec) {
     throw fs::filesystem_error("Cannot move a temporary file", path(), to, ec);
   }
-}
 
-void file::move(const fs::path& to, std::error_code& ec) {
-  filebuf.close();
-  tmp::move(*this, to, ec);
-  if (!ec) {
-    entry::clear();
-  }
+  entry::clear();
 }
 
 file::~file() noexcept = default;


### PR DESCRIPTION
I only needed that for tidier code in `file` input/output operations