### PR TITLE
Add `openmode` parameter for file creation

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -43,29 +43,23 @@ public:
   /// in binary mode
   /// @param[in] label     A label to attach to the temporary file path
   /// @param[in] extension An extension of the temporary file path
+  /// @param[in] mode      Specifies stream open mode
   /// @throws std::filesystem::filesystem_error if cannot create a file
   /// @throws std::invalid_argument             if arguments are ill-formatted
-  explicit file(std::string_view label = "", std::string_view extension = "");
-
-  /// Creates a unique temporary file and opens it for reading and writing
-  /// in text mode
-  /// @param label     A label to attach to the temporary file path
-  /// @param extension An extension of the temporary file path
-  /// @throws std::filesystem::filesystem_error if cannot create a file
-  /// @throws std::invalid_argument             if arguments are ill-formatted
-  static file text(std::string_view label = "",
-                   std::string_view extension = "");
+  explicit file(std::string_view label = "", std::string_view extension = "",
+                std::ios::openmode mode = std::ios::in | std::ios::out);
 
   /// Creates a unique temporary copy from the given path
-  /// @param path      A path to make a temporary copy from
-  /// @param label     A label to attach to the temporary file path
-  /// @param extension An extension of the temporary file path
+  /// @param[in] path      A path to make a temporary copy from
+  /// @param[in] label     A label to attach to the temporary file path
+  /// @param[in] extension An extension of the temporary file path
+  /// @param[in] mode      Specifies stream open mode
   /// @returns The new temporary file
   /// @throws std::filesystem::filesystem_error if given path is not a file
   /// @throws std::invalid_argument             if arguments are ill-formatted
   static file copy(const std::filesystem::path& path,
-                   std::string_view label = "",
-                   std::string_view extension = "");
+                   std::string_view label = "", std::string_view extension = "",
+                   std::ios::openmode mode = std::ios::in | std::ios::out);
 
   /// Moves the managed file to a given target, releasing
   /// ownership of the managed file; behaves like `std::filesystem::rename`

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -12,30 +12,18 @@
 #include <utility>
 
 namespace tmp {
-namespace {
-
-/// A mode to open a text file with
-constexpr std::ios::openmode text_mode = std::ios::in | std::ios::out;
-
-/// A mode to open a binary file with
-constexpr std::ios::openmode binary_mode = std::ios::binary | text_mode;
-}    // namespace
 
 file::file(std::pair<std::filesystem::path, std::filebuf> handle) noexcept
     : entry(std::move(handle.first)),
       std::iostream(&filebuf),
       filebuf(std::move(handle.second)) {}
 
-file::file(std::string_view label, std::string_view extension)
-    : file(create_file(label, extension, binary_mode)) {}
-
-file file::text(std::string_view label, std::string_view extension) {
-  return file(create_file(label, extension, text_mode));
-}
+file::file(std::string_view label, std::string_view extension, openmode mode)
+    : file(create_file(label, extension, mode)) {}
 
 file file::copy(const fs::path& path, std::string_view label,
-                std::string_view extension) {
-  file tmpfile = file(label, extension);
+                std::string_view extension, openmode mode) {
+  file tmpfile = file(label, extension, mode);
 
   std::error_code ec;
   fs::copy_file(path, tmpfile, fs::copy_options::overwrite_existing, ec);


### PR DESCRIPTION
Instead of proving a bunch of overloads for `file`, `file::text` and `file::copy`, provide a way to specify the openmode for the client

This mode will be used for opening a `std::filebuf`