### PR TITLE
Add `file::rdbuf` method

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -63,6 +63,10 @@ public:
                    std::string_view label = "", std::string_view extension = "",
                    std::ios::openmode mode = std::ios::in | std::ios::out);
 
+  /// Returns pointer to the underlying raw file device object
+  /// @returns A pointer to the underlying raw file device
+  std::filebuf* rdbuf() const;
+
   /// Moves the managed file to a given target, releasing
   /// ownership of the managed file; behaves like `std::filesystem::rename`
   /// even when moving between filesystems

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -36,6 +36,11 @@ file file::copy(const fs::path& path, std::string_view label,
   return tmpfile;
 }
 
+std::filebuf* file::rdbuf() const {
+  // For `std::basic_fstream` C++ standard literally requires using `const_cast`
+  return const_cast<std::filebuf*>(std::addressof(sb));    // NOLINT(*-cast)
+}
+
 void file::move(const fs::path& to) {
   sb.close();
 

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -23,8 +23,7 @@ namespace fs = std::filesystem;
 
 /// Returns whether the underlying raw file device object is open
 bool is_open(const file& file) {
-  std::filebuf* filebuf = dynamic_cast<std::filebuf*>(file.rdbuf());
-  return filebuf != nullptr && filebuf->is_open();
+  return file.rdbuf()->is_open();
 }
 
 /// Tests file creation with label


### PR DESCRIPTION
Like in `std::fstream`, the `file::rdbuf` method hides the non-virtual method `std::basic_ios::rdbuf` to allow users to obtain a pointer to a stream buffer of type `std::filebuf` without using dynamic casts

This also allows users to get a C++26 `native_handle`:
```cpp
tmp::file().rdbuf()->native_handle()
```