### PR TITLE
Implement a custom `filebuf` for opening a native handle

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -104,7 +104,8 @@ private:
 
   /// Creates a unique temporary file
   /// @param handle A path to the created temporary file and a handle to it
-  explicit file(std::pair<std::filesystem::path, filebuf> handle) TMP_NO_EXPORT;
+  explicit file(std::pair<std::filesystem::path, filebuf> handle) noexcept
+      TMP_NO_EXPORT;
 };
 }    // namespace tmp
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -3,6 +3,7 @@
 
 #include <tmp/entry>
 #include <tmp/export>
+#include <tmp/filebuf>
 
 #include <filesystem>
 #include <fstream>
@@ -99,11 +100,12 @@ public:
 
 private:
   /// The underlying raw file device object
-  std::filebuf sb;
+  filebuf sb;
 
   /// Creates a unique temporary file
   /// @param handle A path to the created temporary file and a handle to it
-  explicit file(std::pair<std::filesystem::path, std::filebuf> handle) noexcept
+  /// @param mode
+  explicit file(std::pair<std::filesystem::path, filebuf::native_handle_type> handle, std::ios::openmode mode) noexcept
       TMP_NO_EXPORT;
 };
 }    // namespace tmp

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -104,9 +104,7 @@ private:
 
   /// Creates a unique temporary file
   /// @param handle A path to the created temporary file and a handle to it
-  /// @param mode
-  explicit file(std::pair<std::filesystem::path, filebuf::native_handle_type> handle, std::ios::openmode mode)
-      TMP_NO_EXPORT;
+  explicit file(std::pair<std::filesystem::path, filebuf> handle) TMP_NO_EXPORT;
 };
 }    // namespace tmp
 

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -105,7 +105,7 @@ private:
   /// Creates a unique temporary file
   /// @param handle A path to the created temporary file and a handle to it
   /// @param mode
-  explicit file(std::pair<std::filesystem::path, filebuf::native_handle_type> handle, std::ios::openmode mode) noexcept
+  explicit file(std::pair<std::filesystem::path, filebuf::native_handle_type> handle, std::ios::openmode mode)
       TMP_NO_EXPORT;
 };
 }    // namespace tmp

--- a/include/tmp/filebuf
+++ b/include/tmp/filebuf
@@ -11,7 +11,7 @@ class filebuf : public std::filebuf {
 public:
   /// Implementation-defined handle type to the file
 #if defined(_WIN32)
-  using native_handle_type = void*;    // HANDLE
+  using native_handle_type = std::FILE*;
 #elif __has_include(<unistd.h>)
   using native_handle_type = int;    // POSIX file descriptor
 #else

--- a/include/tmp/filebuf
+++ b/include/tmp/filebuf
@@ -3,10 +3,17 @@
 
 #include <fstream>
 #include <ios>
-#include <string>
 
 namespace tmp {
 
+/// `tmp::basic_filebuf` is a stream buffer whose associated character sequence
+/// is a file; both the input and the output sequences are associated with
+/// the same file, and a joint file position is maintained for both operations
+///
+/// The reason we implement this here rather than using the standard
+/// `std::filebuf` is that the standard does not provide a way to use
+/// an existing open file in a file buffer, and does not even report errors when
+/// opening a file fails
 class filebuf : public std::filebuf {
 public:
   /// Implementation-defined handle type to the file
@@ -18,7 +25,11 @@ public:
 #error "Target platform not supported"
 #endif
 
-  std::filebuf* open(native_handle_type handle, std::ios::openmode mode);
+  /// Opens a file and configures it as the associated character sequence
+  /// @param handle A handle to the open file
+  /// @param mode   The file opening mode
+  /// @returns `this` file buffer, or a null pointer on failure
+  filebuf* open(native_handle_type handle, std::ios::openmode mode);
 };
 }    // namespace tmp
 

--- a/include/tmp/filebuf
+++ b/include/tmp/filebuf
@@ -1,0 +1,25 @@
+#ifndef TMP_FILEBUF_H
+#define TMP_FILEBUF_H
+
+#include <fstream>
+#include <ios>
+#include <string>
+
+namespace tmp {
+
+class filebuf : public std::filebuf {
+public:
+  /// Implementation-defined handle type to the file
+#if defined(_WIN32)
+  using native_handle_type = void*;    // HANDLE
+#elif __has_include(<unistd.h>)
+  using native_handle_type = int;    // POSIX file descriptor
+#else
+#error "Target platform not supported"
+#endif
+
+  filebuf* open(native_handle_type handle, std::ios::openmode mode);
+};
+}    // namespace tmp
+
+#endif    // TMP_FILEBUF_H

--- a/include/tmp/filebuf
+++ b/include/tmp/filebuf
@@ -18,7 +18,7 @@ public:
 #error "Target platform not supported"
 #endif
 
-  filebuf* open(native_handle_type handle, std::ios::openmode mode);
+  std::filebuf* open(native_handle_type handle, std::ios::openmode mode);
 };
 }    // namespace tmp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Filesystem REQUIRED)
 include(GenerateExportHeader)
 
-add_library(${PROJECT_NAME} create.cpp entry.cpp file.cpp directory.cpp move.cpp)
+add_library(${PROJECT_NAME} create.cpp entry.cpp file.cpp directory.cpp move.cpp filebuf.cpp)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_link_libraries(${PROJECT_NAME} PUBLIC std::filesystem)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Filesystem REQUIRED)
 include(GenerateExportHeader)
 
 add_library(${PROJECT_NAME} create.cpp entry.cpp file.cpp directory.cpp move.cpp filebuf.cpp)
+target_compile_definitions(${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_link_libraries(${PROJECT_NAME} PUBLIC std::filesystem)
 

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -196,8 +196,8 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
   }
 
 #ifdef _WIN32
-  std::FILE* handle =
-      _wfopen(path.c_str(), make_mdstring(std::ios::in | std::ios::out));
+  // FIXME: use _wfopen_s
+  std::FILE* handle = _wfopen(path.c_str(), make_mdstring(mode));
   if (handle == nullptr) {
     ec = std::error_code(errno, std::system_category());
     return {};

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -1,8 +1,8 @@
 #include "create.hpp"
 
+#include <tmp/filebuf>
+
 #include <filesystem>
-#include <fstream>
-#include <ios>
 #include <stdexcept>
 #include <string_view>
 #include <system_error>
@@ -107,43 +107,15 @@ fs::path make_pattern(std::string_view label, std::string_view extension) {
 bool create_parent(const fs::path& path, std::error_code& ec) {
   return fs::create_directories(path.parent_path(), ec);
 }
-
-/// Executes the given function when this guard goes out of scope
-template<class Cleanup> struct scope_guard {
-  explicit scope_guard(const Cleanup& cleanup)
-      : cleanup_(cleanup) {}
-  scope_guard(scope_guard&&) = delete;
-  scope_guard& operator=(scope_guard&&) = delete;
-  scope_guard(const scope_guard&) = delete;
-  scope_guard& operator=(const scope_guard&) = delete;
-
-  ~scope_guard() {
-    cleanup_();
-  }
-
-private:
-  Cleanup cleanup_;
-};
-
-/// Closes the given handle, ignoring any errors
-/// @param[in] handle The handle to close
-template<typename Handle> void close(Handle handle) noexcept {
-#ifdef _WIN32
-  CloseHandle(handle);
-#else
-  ::close(handle);
-#endif
-}
 }    // namespace
 
-std::pair<fs::path, std::filebuf> create_file(std::string_view label,
-                                              std::string_view extension,
-                                              std::ios::openmode mode) {
+std::pair<fs::path, filebuf::native_handle_type> create_file(std::string_view label,
+                                              std::string_view extension) {
   validate_label(label);    // throws std::invalid_argument with a proper text
   validate_extension(extension);
 
   std::error_code ec;
-  auto file = create_file(label, extension, mode, ec);
+  auto file = create_file(label, extension, ec);
 
   if (ec) {
     throw fs::filesystem_error("Cannot create a temporary file", ec);
@@ -152,9 +124,8 @@ std::pair<fs::path, std::filebuf> create_file(std::string_view label,
   return file;
 }
 
-std::pair<fs::path, std::filebuf> create_file(std::string_view label,
+std::pair<fs::path, filebuf::native_handle_type> create_file(std::string_view label,
                                               std::string_view extension,
-                                              std::ios::openmode mode,
                                               std::error_code& ec) {
   if (!is_label_valid(label) || !is_extension_valid(extension)) {
     ec = std::make_error_code(std::errc::invalid_argument);
@@ -189,17 +160,8 @@ std::pair<fs::path, std::filebuf> create_file(std::string_view label,
   }
 #endif
 
-  scope_guard on_exit = scope_guard([&] { close(handle); });
-
-  std::filebuf filebuf;
-  filebuf.open(path, mode);
-  if (!filebuf.is_open()) {
-    ec = std::make_error_code(std::io_errc::stream);
-    fs::remove(path);
-  }
-
   ec.clear();
-  return std::make_pair(path, std::move(filebuf));
+  return std::make_pair(path, handle);
 }
 
 fs::path create_directory(std::string_view label) {

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -211,15 +211,15 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
   }
 #endif
 
-  filebuf sb;
-  if (sb.open(handle, mode) == nullptr) {
+  filebuf filebuf;
+  if (filebuf.open(handle, mode) == nullptr) {
     close(handle);
     ec = std::make_error_code(std::io_errc::stream);
     fs::remove(path);
   }
 
   ec.clear();
-  return std::make_pair(path, sb);
+  return std::make_pair(path, std::move(filebuf));
 }
 
 fs::path create_directory(std::string_view label) {

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -4,6 +4,7 @@
 #include <tmp/filebuf>
 
 #include <filesystem>
+#include <ios>
 #include <string_view>
 #include <system_error>
 #include <utility>
@@ -15,21 +16,25 @@ namespace fs = std::filesystem;
 /// temporary directory, and opens it for reading and writing
 /// @param[in] label     A label to attach to the temporary file path
 /// @param[in] extension An extension of the temporary file path
+/// @param[in] mode      Specifies stream open mode
 /// @returns A path to the created temporary file and a handle to it
 /// @throws fs::filesystem_error  if cannot create a temporary file
 /// @throws std::invalid_argument if the label or extension is ill-formatted
-std::pair<fs::path, filebuf::native_handle_type>
-create_file(std::string_view label, std::string_view extension);
+std::pair<fs::path, filebuf> create_file(std::string_view label,
+                                         std::string_view extension,
+                                         std::ios::openmode mode);
 
 /// Creates a temporary file with the given label and extension in the system's
 /// temporary directory, and opens it for reading and writing
 /// @param[in]  label     A label to attach to the temporary file path
 /// @param[in]  extension An extension of the temporary file path
+/// @param[in] mode      Specifies stream open mode
 /// @param[out] ec        Parameter for error reporting
 /// @returns A path to the created temporary file and a handle to it
-std::pair<fs::path, filebuf::native_handle_type>
-create_file(std::string_view label, std::string_view extension,
-            std::error_code& ec);
+std::pair<fs::path, filebuf> create_file(std::string_view label,
+                                         std::string_view extension,
+                                         std::ios::openmode mode,
+                                         std::error_code& ec);
 
 /// Creates a temporary directory with the given label in the system's
 /// temporary directory

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -1,9 +1,9 @@
 #ifndef TMP_CREATE_H
 #define TMP_CREATE_H
 
+#include <tmp/filebuf>
+
 #include <filesystem>
-#include <fstream>
-#include <ios>
 #include <string_view>
 #include <system_error>
 #include <utility>
@@ -15,25 +15,21 @@ namespace fs = std::filesystem;
 /// temporary directory, and opens it for reading and writing
 /// @param[in] label     A label to attach to the temporary file path
 /// @param[in] extension An extension of the temporary file path
-/// @param[in] mode      Specifies stream open mode
 /// @returns A path to the created temporary file and a handle to it
 /// @throws fs::filesystem_error  if cannot create a temporary file
 /// @throws std::invalid_argument if the label or extension is ill-formatted
-std::pair<fs::path, std::filebuf> create_file(std::string_view label,
-                                              std::string_view extension,
-                                              std::ios::openmode mode);
+std::pair<fs::path, filebuf::native_handle_type>
+create_file(std::string_view label, std::string_view extension);
 
 /// Creates a temporary file with the given label and extension in the system's
 /// temporary directory, and opens it for reading and writing
 /// @param[in]  label     A label to attach to the temporary file path
 /// @param[in]  extension An extension of the temporary file path
-/// @param[in]  mode      Specifies stream open mode
 /// @param[out] ec        Parameter for error reporting
 /// @returns A path to the created temporary file and a handle to it
-std::pair<fs::path, std::filebuf> create_file(std::string_view label,
-                                              std::string_view extension,
-                                              std::ios::openmode mode,
-                                              std::error_code& ec);
+std::pair<fs::path, filebuf::native_handle_type>
+create_file(std::string_view label, std::string_view extension,
+            std::error_code& ec);
 
 /// Creates a temporary directory with the given label in the system's
 /// temporary directory

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -13,9 +13,8 @@
 #include <utility>
 
 namespace tmp {
-namespace {}
 
-file::file(std::pair<fs::path, filebuf> handle)
+file::file(std::pair<fs::path, filebuf> handle) noexcept
     : entry(std::move(handle.first)),
       std::iostream(std::addressof(sb)),
       sb(std::move(handle.second)) {}

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -12,37 +12,16 @@
 #include <system_error>
 #include <utility>
 
-#ifdef _WIN32
-#define <cstdio>
-#else
-#include <unistd.h>
-#endif
-
 namespace tmp {
-namespace {
-/// Closes the given handle, ignoring any errors
-/// @param[in] handle The handle to close
-void close(filebuf::native_handle_type handle) noexcept {
-#ifdef _WIN32
-  fclose(handle);
-#else
-  ::close(handle);
-#endif
-}
-}
+namespace {}
 
-file::file(std::pair<fs::path, filebuf::native_handle_type> handle, openmode mode)
+file::file(std::pair<fs::path, filebuf> handle)
     : entry(std::move(handle.first)),
-      std::iostream(std::addressof(sb)) {
-  if (sb.open(handle.second, mode) == nullptr) {
-    close(handle.second);
-    std::error_code ec = std::make_error_code(std::io_errc::stream);
-    throw fs::filesystem_error("Cannot create a temporary file", ec);
-  }
-}
+      std::iostream(std::addressof(sb)),
+      sb(std::move(handle.second)) {}
 
 file::file(std::string_view label, std::string_view extension, openmode mode)
-    : file(create_file(label, extension), mode) {}
+    : file(create_file(label, extension, mode)) {}
 
 file file::copy(const fs::path& path, std::string_view label,
                 std::string_view extension, openmode mode) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -14,13 +14,14 @@
 
 namespace tmp {
 
-file::file(std::pair<std::filesystem::path, std::filebuf> handle) noexcept
+file::file(std::pair<std::filesystem::path, filebuf::native_handle_type> handle, openmode mode) noexcept
     : entry(std::move(handle.first)),
-      std::iostream(std::addressof(sb)),
-      sb(std::move(handle.second)) {}
+      std::iostream(std::addressof(sb)) {
+  sb.open(handle.second, mode);
+}
 
 file::file(std::string_view label, std::string_view extension, openmode mode)
-    : file(create_file(label, extension, mode)) {}
+    : file(create_file(label, extension), mode) {}
 
 file file::copy(const fs::path& path, std::string_view label,
                 std::string_view extension, openmode mode) {
@@ -37,8 +38,7 @@ file file::copy(const fs::path& path, std::string_view label,
 }
 
 std::filebuf* file::rdbuf() const noexcept {
-  // For `std::fstream` the C++ standard literally requires using `const_cast`
-  return const_cast<std::filebuf*>(std::addressof(sb));    // NOLINT(*-cast)
+  return const_cast<filebuf*>(std::addressof(sb));    // NOLINT(*-const-cast)
 }
 
 void file::move(const fs::path& to) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -54,7 +54,9 @@ void file::move(const fs::path& to) {
   entry::clear();
 }
 
-file::~file() noexcept = default;
+file::~file() noexcept {
+  sb.close();
+}
 
 // NOLINTBEGIN(*-use-after-move)
 file::file(file&& other) noexcept

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -15,12 +15,12 @@ namespace tmp {
 namespace {
 }
 
-filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
+std::filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
 #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 70000
   // LLVM libc++ supports filesystem library since version 7
   // Apple LLVM, despite having a different version scheme still supplies original _LIBCPP_VERSION
   // Apple Clang supports filesystem library since version 11.0.0, and requires macOS 10.15 or newer (TODO: check other apple platforms?)
-  return this->__open(handle, mode) ? this : nullptr;
+  return this->__open(handle, mode);
 #elif defined(__GLIBCXX__)    // TODO: check versions
   // GCC libstdc++ supports filesystem library since 8
   // https://en.cppreference.com/w/cpp/compiler_support/17#C.2B.2B17_library_features

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -3,8 +3,8 @@
 #include <ios>
 
 #ifdef _WIN32
-#include <cstdio>
 #include <corecrt_io.h>
+#include <cstdio>
 #endif
 
 #if __has_include(<__config>)
@@ -12,20 +12,12 @@
 #endif
 
 namespace tmp {
-namespace {
-}
 
-std::filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 70000
-  // LLVM libc++ supports filesystem library since version 7
-  // Apple LLVM, despite having a different version scheme still supplies original _LIBCPP_VERSION
-  // Apple Clang supports filesystem library since version 11.0.0, and requires macOS 10.15 or newer (TODO: check other apple platforms?)
-  return this->__open(handle, mode);
-#elif defined(__GLIBCXX__)    // TODO: check versions
-  // GCC libstdc++ supports filesystem library since 8
-  // https://en.cppreference.com/w/cpp/compiler_support/17#C.2B.2B17_library_features
-
-  // On libstdc++ we replicate a standard `std::basic_filebuf::open`
+filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
+#if defined(_LIBCPP_VERSION)
+  return this->__open(handle, mode) != nullptr ? this : nullptr;
+#elif defined(__GLIBCXX__)
+  // We replicate the standard `std::basic_filebuf::open`
   this->_M_file.sys_open(handle, mode);
   if (this->is_open()) {
     this->_M_allocate_internal_buffer();
@@ -42,17 +34,15 @@ std::filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) 
   }
 
   return nullptr;
-#endif
-
-#if defined(_MSC_VER) && _MSC_VER >= 1914
+#elif defined(_MSC_VER)
   if (handle == nullptr) {
     return nullptr;
   }
 
   _Init(handle, _Newfl);
   return this;
+#elif
+#error "Target C++ standard library is not supported"
 #endif
-
-  // Other C++ STL implementations may be supported if needed and possible
 }
-}
+}    // namespace tmp

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -1,10 +1,61 @@
 #include <tmp/filebuf>
 
+#include <ios>
+
+#ifdef _WIN32
+#include <cstdio>
+#include <corecrt_io.h>
+#endif
+
 #if __has_include(<__config>)
 #include <__config>    // libc++ configuration
 #endif
 
 namespace tmp {
+namespace {
+
+#ifdef _WIN32
+/// Makes a mode string for the `fdopen` function
+/// @param mode The file opening mode
+/// @returns A suitable mode string
+const char* make_mdstring(std::ios::openmode mode) noexcept {
+  switch (mode & ~std::ios::ate) {
+  case std::ios::out:
+  case std::ios::out | std::ios::trunc:
+    return "w";
+  case std::ios::out | std::ios::app:
+  case std::ios::app:
+    return "a";
+  case std::ios::in:
+    return "r";
+  case std::ios::in | std::ios::out:
+    return "r+";
+  case std::ios::in | std::ios::out | std::ios::trunc:
+    return "w+";
+  case std::ios::in | std::ios::out | std::ios::app:
+  case std::ios::in | std::ios::app:
+    return "a+";
+  case std::ios::out | std::ios::binary:
+  case std::ios::out | std::ios::trunc | std::ios::binary:
+    return "wb";
+  case std::ios::out | std::ios::app | std::ios::binary:
+  case std::ios::app | std::ios::binary:
+    return "ab";
+  case std::ios::in | std::ios::binary:
+    return "rb";
+  case std::ios::in | std::ios::out | std::ios::binary:
+    return "r+b";
+  case std::ios::in | std::ios::out | std::ios::trunc | std::ios::binary:
+    return "w+b";
+  case std::ios::in | std::ios::out | std::ios::app | std::ios::binary:
+  case std::ios::in | std::ios::app | std::ios::binary:
+    return "a+b";
+  default:
+    return nullptr;
+  }
+}
+#endif
+}
 
 filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
 #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 70000
@@ -35,7 +86,17 @@ filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
   return nullptr;
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER >= 1914
   // MSVC STL supports filesystem library since version 19.14 (VS 2017 15.7)
+  int fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), 0);
+  std::FILE* file = _fdopen(fd, make_mdstring(mode));
+  if (file == nullptr) {
+    return nullptr;
+  }
+
+  _Init(file, _Newfl);
+  return this;
+#endif
 
   // Other C++ STL implementations may be supported if needed and possible
 }

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -2,11 +2,6 @@
 
 #include <ios>
 
-#ifdef _WIN32
-#include <corecrt_io.h>
-#include <cstdio>
-#endif
-
 #if __has_include(<__config>)
 #include <__config>    // libc++ configuration
 #endif

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -1,0 +1,42 @@
+#include <tmp/filebuf>
+
+#if __has_include(<__config>)
+#include <__config>    // libc++ configuration
+#endif
+
+namespace tmp {
+
+filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 70000
+  // LLVM libc++ supports filesystem library since version 7
+  // Apple LLVM, despite having a different version scheme still supplies original _LIBCPP_VERSION
+  // Apple Clang supports filesystem library since version 11.0.0, and requires macOS 10.15 or newer (TODO: check other apple platforms?)
+  return this->__open(handle, mode) ? this : nullptr;
+#elif defined(__GLIBCXX__)    // TODO: check versions
+  // GCC libstdc++ supports filesystem library since 8
+  // https://en.cppreference.com/w/cpp/compiler_support/17#C.2B.2B17_library_features
+
+  // On libstdc++ we replicate a standard `std::basic_filebuf::open`
+  this->_M_file.sys_open(handle, mode);
+  if (this->is_open()) {
+    this->_M_allocate_internal_buffer();
+    this->_M_mode = mode;
+
+    // Setup initial buffer to 'uncommitted' mode
+    this->_M_reading = false;
+    this->_M_writing = false;
+    this->_M_set_buffer(-1);
+
+    // Reset to initial state
+    this->_M_state_last = this->_M_state_cur = this->_M_state_beg;
+    return this;
+  }
+
+  return nullptr;
+#endif
+
+  // MSVC STL supports filesystem library since version 19.14 (VS 2017 15.7)
+
+  // Other C++ STL implementations may be supported if needed and possible
+}
+}

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -13,48 +13,6 @@
 
 namespace tmp {
 namespace {
-
-#ifdef _WIN32
-/// Makes a mode string for the `fdopen` function
-/// @param mode The file opening mode
-/// @returns A suitable mode string
-const char* make_mdstring(std::ios::openmode mode) noexcept {
-  switch (mode & ~std::ios::ate) {
-  case std::ios::out:
-  case std::ios::out | std::ios::trunc:
-    return "w";
-  case std::ios::out | std::ios::app:
-  case std::ios::app:
-    return "a";
-  case std::ios::in:
-    return "r";
-  case std::ios::in | std::ios::out:
-    return "r+";
-  case std::ios::in | std::ios::out | std::ios::trunc:
-    return "w+";
-  case std::ios::in | std::ios::out | std::ios::app:
-  case std::ios::in | std::ios::app:
-    return "a+";
-  case std::ios::out | std::ios::binary:
-  case std::ios::out | std::ios::trunc | std::ios::binary:
-    return "wb";
-  case std::ios::out | std::ios::app | std::ios::binary:
-  case std::ios::app | std::ios::binary:
-    return "ab";
-  case std::ios::in | std::ios::binary:
-    return "rb";
-  case std::ios::in | std::ios::out | std::ios::binary:
-    return "r+b";
-  case std::ios::in | std::ios::out | std::ios::trunc | std::ios::binary:
-    return "w+b";
-  case std::ios::in | std::ios::out | std::ios::app | std::ios::binary:
-  case std::ios::in | std::ios::app | std::ios::binary:
-    return "a+b";
-  default:
-    return nullptr;
-  }
-}
-#endif
 }
 
 filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
@@ -87,14 +45,11 @@ filebuf* filebuf::open(native_handle_type handle, std::ios::openmode mode) {
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1914
-  // MSVC STL supports filesystem library since version 19.14 (VS 2017 15.7)
-  int fd = _open_osfhandle(reinterpret_cast<intptr_t>(handle), 0);
-  std::FILE* file = _fdopen(fd, make_mdstring(mode));
-  if (file == nullptr) {
+  if (handle == nullptr) {
     return nullptr;
   }
 
-  _Init(file, _Newfl);
+  _Init(handle, _Newfl);
   return this;
 #endif
 


### PR DESCRIPTION
Closes #160

This is a very hacky way to open a native handle in the three main C++ standard library implementations

I really don't want to implement filebuf myself