### PR TITLE
Always open `file` with `in` and `out` flags

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -47,7 +47,7 @@ namespace tmp {
 class TMP_EXPORT file : public entry, public std::iostream {
 public:
   /// Creates a unique temporary file and opens it for reading and writing
-  /// in binary mode
+  /// @note std::ios::in | std::ios::out are always added to the `mode`
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path
   /// @param mode      Specifies stream open mode
@@ -57,6 +57,7 @@ public:
                 std::ios::openmode mode = std::ios::in | std::ios::out);
 
   /// Creates a unique temporary copy from the given path
+  /// @note std::ios::in | std::ios::out are always added to the `mode`
   /// @param path      A path to make a temporary copy from
   /// @param label     A label to attach to the temporary file path
   /// @param extension An extension of the temporary file path

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -218,6 +218,7 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
     close(handle);
     ec = std::make_error_code(std::io_errc::stream);
     fs::remove(path);
+    return {};
   }
 
   ec.clear();

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -211,6 +211,8 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
   }
 #endif
 
+  mode |= std::ios::in | std::ios::out;
+
   filebuf filebuf;
   if (filebuf.open(handle, mode) == nullptr) {
     close(handle);

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -137,7 +137,6 @@ const wchar_t* make_mdstring(std::ios::openmode mode) noexcept {
   case std::ios::in | std::ios::binary:
     return L"rb";
   case std::ios::in | std::ios::out | std::ios::binary:
-    return L"r+b";
   case std::ios::in | std::ios::out | std::ios::trunc | std::ios::binary:
     return L"w+bx";
   case std::ios::in | std::ios::out | std::ios::app | std::ios::binary:
@@ -195,6 +194,8 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
     return {};
   }
 
+  mode |= std::ios::in | std::ios::out;
+
 #ifdef _WIN32
   // FIXME: use _wfopen_s
   std::FILE* handle = _wfopen(path.c_str(), make_mdstring(mode));
@@ -210,8 +211,6 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
     return {};
   }
 #endif
-
-  mode |= std::ios::in | std::ios::out;
 
   filebuf filebuf;
   if (filebuf.open(handle, mode) == nullptr) {

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -127,6 +127,16 @@ TEST(file, create_invalid_extension) {
   EXPECT_THROW(file("", "/."), std::invalid_argument);
 }
 
+/// Tests that file add std::ios::in and std::ios::out flags
+TEST(file, ios_flags) {
+  file tmpfile = file("", "", std::ios::binary);
+  tmpfile << "Hello, world!" << std::flush;
+
+  std::ifstream stream = std::ifstream(tmpfile.path());
+  std::string content = std::string(std::istreambuf_iterator(stream), {});
+  EXPECT_EQ(content, "Hello, world!");
+}
+
 /// Tests creation of a temporary copy of a file
 TEST(file, copy_file) {
   file tmpfile = file();


### PR DESCRIPTION
Closes #166

A temporary file now always adds `std::ios::in | std::ios::out` to its open flags

In light of https://github.com/bugdea1er/tmp/issues/165 there is no point in opening a temporary file without the `std::ios::in` or `std::ios::out` flag, since otherwise it will be impossible to fill it or read its contents

Also fixed an error where an exception was not thrown if failed to open a filebuf