### PR TITLE
Fixed a bug where invalid open mode was not handled correctly.

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -197,10 +197,17 @@ std::pair<fs::path, filebuf> create_file(std::string_view label,
   mode |= std::ios::in | std::ios::out;
 
 #ifdef _WIN32
+  std::FILE* handle;
+
   // FIXME: use _wfopen_s
-  std::FILE* handle = _wfopen(path.c_str(), make_mdstring(mode));
-  if (handle == nullptr) {
-    ec = std::error_code(errno, std::system_category());
+  if (const wchar_t* mdstr = make_mdstring(mode)) {
+    handle = _wfopen(path.c_str(), mdstr);
+    if (handle == nullptr) {
+      ec = std::error_code(errno, std::system_category());
+      return {};
+    }
+  } else {
+    ec = std::make_error_code(std::errc::invalid_argument);
     return {};
   }
 #else

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -127,7 +127,14 @@ TEST(file, create_invalid_extension) {
   EXPECT_THROW(file("", "/."), std::invalid_argument);
 }
 
-/// Tests that file add std::ios::in and std::ios::out flags
+/// Tests error handling with invalid open mode
+TEST(file, create_invalid_openmode) {
+  // C++ standard forbids opening a filebuf with `trunc | app`
+  std::ios::openmode openmode = std::ios::trunc | std::ios::app;
+  EXPECT_THROW(file("", "", openmode), fs::filesystem_error);
+}
+
+/// Tests that file adds std::ios::in and std::ios::out flags
 TEST(file, ios_flags) {
   file tmpfile = file("", "", std::ios::binary);
   tmpfile << "Hello, world!" << std::flush;


### PR DESCRIPTION
For some `std::ios::openmode` flags, the resulting mode string was `nullptr` and was not checked before calling `fopen`