### PR TITLE
Replace directory labels with prefixes

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -38,19 +38,19 @@ namespace tmp {
 class TMP_EXPORT directory : public entry {
 public:
   /// Creates a unique temporary directory
-  /// @param label A label to attach to the temporary directory path
+  /// @param prefix A prefix to attach to the temporary directory path
   /// @throws std::filesystem::filesystem_error if cannot create a directory
-  /// @throws std::invalid_argument             if the label is ill-formatted
-  explicit directory(std::string_view label = "");
+  /// @throws std::invalid_argument             if the prefix is ill-formatted
+  explicit directory(std::string_view prefix = "");
 
   /// Creates a unique temporary copy recursively from the given path
-  /// @param path  A path to make a temporary copy from
-  /// @param label A label to attach to the temporary directory path
+  /// @param path   A path to make a temporary copy from
+  /// @param prefix A prefix to attach to the temporary directory path
   /// @returns The new temporary directory
   /// @throws std::filesystem::filesystem_error if given path is not a directory
-  /// @throws std::invalid_argument             if the label is ill-formatted
+  /// @throws std::invalid_argument             if the prefix is ill-formatted
   static directory copy(const std::filesystem::path& path,
-                        std::string_view label = "");
+                        std::string_view prefix = "");
 
   /// Concatenates this directory path with a given source
   /// @param source A string which represents a path name

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -77,14 +77,6 @@ fs::path make_pattern(std::string_view prefix) {
 }
 #endif
 
-/// Creates the parent directory of the given path if it does not exist
-/// @param[in]  path The path for which the parent directory needs to be created
-/// @param[out] ec   Parameter for error reporting
-/// @returns `true` if a parent directory was newly created, `false` otherwise
-bool create_parent(const fs::path& path, std::error_code& ec) {
-  return fs::create_directories(path.parent_path(), ec);
-}
-
 #ifdef _WIN32
 /// Makes a mode string for the `_wfdopen` function
 /// @param mode The file opening mode
@@ -154,10 +146,6 @@ std::pair<fs::path, filebuf> create_file(std::ios::openmode mode,
 #else
   fs::path::string_type path = make_pattern("");
 #endif
-  create_parent(path, ec);
-  if (ec) {
-    return {};
-  }
 
   mode |= std::ios::in | std::ios::out;
 
@@ -219,10 +207,6 @@ fs::path create_directory(std::string_view prefix, std::error_code& ec) {
 #else
   fs::path::string_type path = make_pattern(prefix);
 #endif
-  create_parent(path, ec);
-  if (ec) {
-    return fs::path();
-  }
 
 #ifdef _WIN32
   if (!CreateDirectory(path.c_str(), nullptr)) {

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -71,7 +71,7 @@ fs::path make_path(std::string_view prefix) {
 /// @returns A path pattern for the unique temporary path
 fs::path make_pattern(std::string_view prefix) {
   fs::path path = fs::temp_directory_path() / prefix;
-  path += "XXXXXX";
+  path += "XXXXXX";    // TODO: add '.', like `com.github.bugdea1er.tmp.yotR2k`?
 
   return path;
 }

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -27,20 +27,20 @@ std::pair<fs::path, filebuf> create_file(std::ios::openmode mode);
 std::pair<fs::path, filebuf> create_file(std::ios::openmode mode,
                                          std::error_code& ec);
 
-/// Creates a temporary directory with the given label in the system's
+/// Creates a temporary directory with the given prefix in the system's
 /// temporary directory
-/// @param[in] label A label to attach to the temporary directory path
+/// @param[in] prefix A prefix to attach to the temporary directory name
 /// @returns A path to the created temporary directory
 /// @throws fs::filesystem_error  if cannot create a temporary directory
-/// @throws std::invalid_argument if the label is ill-formatted
-fs::path create_directory(std::string_view label);
+/// @throws std::invalid_argument if the prefix is ill-formatted
+fs::path create_directory(std::string_view prefix);
 
-/// Creates a temporary directory with the given label in the system's
+/// Creates a temporary directory with the given prefix in the system's
 /// temporary directory
-/// @param[in]  label A label to attach to the temporary directory path
+/// @param[in]  prefix A prefix to attach to the temporary directory name
 /// @param[out] ec    Parameter for error reporting
 /// @returns A path to the created temporary directory
-fs::path create_directory(std::string_view label, std::error_code& ec);
+fs::path create_directory(std::string_view prefix, std::error_code& ec);
 }    // namespace tmp
 
 #endif    // TMP_CREATE_H

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -16,11 +16,11 @@ constexpr fs::copy_options copy_options =
     fs::copy_options::recursive | fs::copy_options::overwrite_existing;
 }    // namespace
 
-directory::directory(std::string_view label)
-    : entry(create_directory(label)) {}
+directory::directory(std::string_view prefix)
+    : entry(create_directory(prefix)) {}
 
-directory directory::copy(const fs::path& path, std::string_view label) {
-  directory tmpdir = directory(label);
+directory directory::copy(const fs::path& path, std::string_view prefix) {
+  directory tmpdir = directory(prefix);
 
   std::error_code ec;
   if (fs::is_directory(path)) {

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -59,11 +59,6 @@ void remove(const fs::path& path) noexcept {
     try {
       std::error_code ec;
       fs::remove_all(path, ec);
-
-      fs::path parent = path.parent_path();
-      if (!fs::equivalent(parent, fs::temp_directory_path(), ec)) {
-        fs::remove(parent, ec);
-      }
     } catch (const std::bad_alloc& ex) {
       static_cast<void>(ex);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(GTest)
 add_executable(${PROJECT_NAME} directory.cpp file.cpp)
 target_link_libraries(${PROJECT_NAME} tmp::tmp GTest::gtest_main)
 target_compile_definitions(${PROJECT_NAME}
-  PRIVATE LABEL="com.github.bugdea1er.tmp"
+  PRIVATE PREFIX="com.github.bugdea1er.tmp"
   BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
 # On some platforms (e.g. Windows) CMake doesn't write load paths properly

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,7 @@ find_package(GTest)
 add_executable(${PROJECT_NAME} directory.cpp file.cpp)
 target_link_libraries(${PROJECT_NAME} tmp::tmp GTest::gtest_main)
 target_compile_definitions(${PROJECT_NAME}
-  PRIVATE PREFIX="com.github.bugdea1er.tmp"
-  BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+  PRIVATE BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
 # On some platforms (e.g. Windows) CMake doesn't write load paths properly
 # This solution to put outputs in the same directory is good enough

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -14,9 +14,12 @@ namespace {
 
 namespace fs = std::filesystem;
 
+/// Temporary directory prefix for this test suite
+constexpr std::string_view prefix = "com.github.bugdea1er.tmp";
+
 /// Tests directory creation with prefix
 TEST(directory, create_with_prefix) {
-  directory tmpdir = directory(PREFIX);
+  directory tmpdir = directory(prefix);
   fs::path parent = tmpdir.path().parent_path();
 
   EXPECT_TRUE(fs::exists(tmpdir));
@@ -24,7 +27,7 @@ TEST(directory, create_with_prefix) {
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
 
   fs::path::string_type filename = tmpdir.path().filename();
-  EXPECT_EQ(filename.substr(0, std::string(PREFIX).length()), fs::path(PREFIX));
+  EXPECT_EQ(filename.substr(0, prefix.length()), fs::path(prefix));
 
   fs::perms permissions = fs::status(tmpdir).permissions();
 #ifdef _WIN32
@@ -48,8 +51,8 @@ TEST(directory, create_without_prefix) {
 
 /// Tests multiple directories creation with the same prefix
 TEST(directory, create_multiple) {
-  directory fst = directory(PREFIX);
-  directory snd = directory(PREFIX);
+  directory fst = directory(prefix);
+  directory snd = directory(prefix);
 
   EXPECT_FALSE(fs::equivalent(fst, snd));
 }

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -5,7 +5,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <gmock/gmock.h>
 #include <iterator>
 #include <stdexcept>
 #include <utility>
@@ -23,7 +22,9 @@ TEST(directory, create_with_prefix) {
   EXPECT_TRUE(fs::exists(tmpdir));
   EXPECT_TRUE(fs::is_directory(tmpdir));
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
-  EXPECT_THAT(tmpdir.path().filename(), testing::StartsWith(PREFIX));
+
+  fs::path::string_type filename = tmpdir.path().filename();
+  EXPECT_EQ(filename.substr(0, std::string(PREFIX).length()), fs::path(PREFIX));
 
   fs::perms permissions = fs::status(tmpdir).permissions();
 #ifdef _WIN32

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <gmock/gmock.h>
 #include <iterator>
 #include <stdexcept>
 #include <utility>
@@ -14,14 +15,15 @@ namespace {
 
 namespace fs = std::filesystem;
 
-/// Tests directory creation with label
-TEST(directory, create_with_label) {
-  directory tmpdir = directory(LABEL);
+/// Tests directory creation with prefix
+TEST(directory, create_with_prefix) {
+  directory tmpdir = directory(PREFIX);
   fs::path parent = tmpdir.path().parent_path();
 
   EXPECT_TRUE(fs::exists(tmpdir));
   EXPECT_TRUE(fs::is_directory(tmpdir));
-  EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path() / LABEL));
+  EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
+  EXPECT_THAT(tmpdir.path().filename(), testing::StartsWith(PREFIX));
 
   fs::perms permissions = fs::status(tmpdir).permissions();
 #ifdef _WIN32
@@ -33,8 +35,8 @@ TEST(directory, create_with_label) {
 #endif
 }
 
-/// Tests directory creation without label
-TEST(directory, create_without_label) {
+/// Tests directory creation without prefix
+TEST(directory, create_without_prefix) {
   directory tmpdir = directory();
   fs::path parent = tmpdir.path().parent_path();
 
@@ -43,16 +45,16 @@ TEST(directory, create_without_label) {
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
 }
 
-/// Tests multiple directories creation with the same label
+/// Tests multiple directories creation with the same prefix
 TEST(directory, create_multiple) {
-  directory fst = directory(LABEL);
-  directory snd = directory(LABEL);
+  directory fst = directory(PREFIX);
+  directory snd = directory(PREFIX);
 
   EXPECT_FALSE(fs::equivalent(fst, snd));
 }
 
-/// Tests error handling with invalid labels
-TEST(directory, create_invalid_label) {
+/// Tests error handling with invalid prefixes
+TEST(directory, create_invalid_prefix) {
   EXPECT_THROW(directory("multi/segment"), std::invalid_argument);
   EXPECT_THROW(directory("/root"), std::invalid_argument);
   EXPECT_THROW(directory(".."), std::invalid_argument);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,7 +6,6 @@ unit_test = executable(
   'file.cpp',
   dependencies: [gtest_main_dep, tmp_dep],
   cpp_args: [
-    '-DPREFIX="com.github.bugdea1er.tmp"',
     '-DBUILD_DIR="' + meson.current_build_dir() + '"',
   ],
   build_by_default: false,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,7 +6,7 @@ unit_test = executable(
   'file.cpp',
   dependencies: [gtest_main_dep, tmp_dep],
   cpp_args: [
-    '-DLABEL="com.github.bugdea1er.tmp"',
+    '-DPREFIX="com.github.bugdea1er.tmp"',
     '-DBUILD_DIR="' + meson.current_build_dir() + '"',
   ],
   build_by_default: false,


### PR DESCRIPTION
The `string_view` argument to the `directory` constructor no longer serves as a parent name to the temporary directory; instead, it is now used as a prefix to the directory name

This is done because:
- This is closer to the `mktemp` documentation examples, which create `tmp.XXXXXX` paths rather than `tmp/XXXXXX`
- If one user program created a directory with a parent `label`, then another user program would sometimes fail to create a directory with the same label

Also, the parent directory for temporary directories is no longer forced to be created. The C++ standard requires `std::filesystem::temp_directory_path()` to return an existing directory; if it is deleted after getting the path and before creating our directory, we choose to fail as soon as possible