### PR TITLE
Breaking: Remove `file::rdbuf`

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -68,10 +68,6 @@ public:
   /// @returns The underlying implementation-defined handle
   native_handle_type native_handle() const noexcept;
 
-  /// Returns pointer to the underlying raw file device object
-  /// @returns A pointer to the underlying raw file device
-  std::filebuf* rdbuf() const noexcept;
-
   /// Moves the managed file to a given target, releasing
   /// ownership of the managed file; behaves like `std::filesystem::rename`
   /// even when moving between filesystems

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -39,10 +39,6 @@ file::native_handle_type file::native_handle() const noexcept {
   return sb.native_handle();
 }
 
-std::filebuf* file::rdbuf() const noexcept {
-  return const_cast<filebuf*>(std::addressof(sb));    // NOLINT(*-const-cast)
-}
-
 void file::move(const fs::path& to) {
   sb.close();
 

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -23,7 +23,8 @@ namespace fs = std::filesystem;
 
 /// Returns whether the underlying raw file device object is open
 bool is_open(const file& file) {
-  return file.rdbuf()->is_open();
+  std::filebuf* filebuf = dynamic_cast<std::filebuf*>(file.rdbuf());
+  return filebuf != nullptr && filebuf->is_open();
 }
 
 /// Checks if the given file handle is valid


### PR DESCRIPTION
`file` (which extends `std::iostream`) still provides `rdbuf() -> std::streambuf` which can be used for lower level I/O

`std::filebuf` (and `tmp::filebuf`) only provides `open`, `is_open` and `close` methods:
- `open` - we don't want the user to be able to reopen another file from the temporary file
- `close` - we don't want `file` to exist in a closed state
- `is_open` - will only return `false` for relocated `file` objects