### PR TITLE
Add a period to prefix if it's not empty

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -56,11 +56,9 @@ fs::path make_path(std::string_view prefix) {
       prefix.empty() ? L"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X"
                      : L".%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X";
 
-  swprintf(name.data(), name.size(),
-           format, guid.Data1,
-           guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2],
-           guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6],
-           guid.Data4[7]);
+  swprintf(name.data(), name.size(), format, guid.Data1, guid.Data2, guid.Data3,
+           guid.Data4[0], guid.Data4[1], guid.Data4[2], guid.Data4[3],
+           guid.Data4[4], guid.Data4[5], guid.Data4[6], guid.Data4[7]);
 
   fs::path path = fs::temp_directory_path() / prefix;
   path += name.data();

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -8,6 +8,7 @@
 #ifdef _WIN32
 #define UNICODE
 #include <Windows.h>
+#include <array>
 #include <cwchar>
 #else
 #include <cerrno>
@@ -45,19 +46,24 @@ void validate_prefix(const fs::path& prefix) {
 /// @param[in] prefix A prefix to attach to the path pattern
 /// @returns A unique temporary path
 fs::path make_path(std::string_view prefix) {
-  constexpr static std::size_t CHARS_IN_GUID = 39;
   GUID guid;
   CoCreateGuid(&guid);
 
-  wchar_t name[CHARS_IN_GUID];
-  swprintf(name, CHARS_IN_GUID,
-           L"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", guid.Data1,
+  constexpr static std::size_t CHARS_IN_GUID = 39;
+  std::array name = std::array<wchar_t, CHARS_IN_GUID>();
+
+  const wchar_t* format =
+      prefix.empty() ? L"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X"
+                     : L".%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X";
+
+  swprintf(name.data(), name.size(),
+           format, guid.Data1,
            guid.Data2, guid.Data3, guid.Data4[0], guid.Data4[1], guid.Data4[2],
            guid.Data4[3], guid.Data4[4], guid.Data4[5], guid.Data4[6],
            guid.Data4[7]);
 
   fs::path path = fs::temp_directory_path() / prefix;
-  path += name;
+  path += name.data();
 
   return path;
 }
@@ -68,7 +74,7 @@ fs::path make_path(std::string_view prefix) {
 /// @returns A path pattern for the unique temporary path
 fs::path make_pattern(std::string_view prefix) {
   fs::path path = fs::temp_directory_path() / prefix;
-  path += "XXXXXX";    // TODO: add '.', like `com.github.bugdea1er.tmp.yotR2k`?
+  path += prefix.empty() ? "XXXXXX" : ".XXXXXX";
 
   return path;
 }

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -28,8 +28,14 @@ TEST(directory, create_with_prefix) {
   EXPECT_TRUE(fs::is_directory(tmpdir));
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
 
+#ifdef _WIN32
+  constexpr std::wstring_view actual_prefix = L"com.github.bugdea1er.tmp.";
+#else
+  constexpr std::string_view actual_prefix = "com.github.bugdea1er.tmp.";
+#endif
+
   fs::path::string_type filename = tmpdir.path().filename();
-  EXPECT_EQ(filename.substr(0, prefix.length()), fs::path(prefix));
+  EXPECT_EQ(filename.substr(0, actual_prefix.length()), actual_prefix);
 
   fs::perms permissions = fs::status(tmpdir).permissions();
 #ifdef _WIN32


### PR DESCRIPTION
After this, directory names will look nicer: `com.github.bugdea1er.tmp.yotR2k` instead of `com.github.bugdea1er.tmpyotR2k`