### PR TITLE
Implement `file::path()`

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -75,10 +75,12 @@ public:
   /// @returns The underlying implementation-defined handle
   native_handle_type native_handle() const noexcept;
 
+#ifndef _WIN32
   /// Returns the path to this file
   /// @note The path is valid only within this process and its children
   /// @returns The full path to this file
   std::filesystem::path path() const;
+#endif
 
   /// Moves the managed file to a given target, releasing
   /// ownership of the managed file; behaves like `std::filesystem::rename`

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -75,6 +75,11 @@ public:
   /// @returns The underlying implementation-defined handle
   native_handle_type native_handle() const noexcept;
 
+  /// Returns the path to this file
+  /// @note The path is valid only within this process and its children
+  /// @returns The full path to this file
+  std::filesystem::path path() const;
+
   /// Moves the managed file to a given target, releasing
   /// ownership of the managed file; behaves like `std::filesystem::rename`
   /// even when moving between filesystems

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -202,13 +202,11 @@ file::native_handle_type file::native_handle() const noexcept {
 #endif
 }
 
+#ifndef _WIN32
 fs::path file::path() const {
-#ifdef __linux__
-  return fs::path("/proc/self/fd") / std::to_string(native_handle());
-#else
   return fs::path("/dev/fd") / std::to_string(native_handle());
-#endif
 }
+#endif
 
 void file::move(const fs::path& to) {
   // TODO: I couldn't figure out how to create a hard link to a file without

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -202,6 +202,14 @@ file::native_handle_type file::native_handle() const noexcept {
 #endif
 }
 
+fs::path file::path() const {
+#ifdef __linux__
+  return fs::path("/proc/self/fd") / std::to_string(native_handle());
+#else
+  return fs::path("/dev/fd") / std::to_string(native_handle());
+#endif
+}
+
 void file::move(const fs::path& to) {
   // TODO: I couldn't figure out how to create a hard link to a file without
   // other hard links, so I just copy it even within the same file system

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -113,6 +113,29 @@ TEST(file, ios_flags) {
   EXPECT_EQ(content, "Hello, world!");
 }
 
+TEST(file, path) {
+  file tmpfile = file();
+  tmpfile << "Hello, world!" << std::flush;
+
+  EXPECT_TRUE(fs::exists(tmpfile.path()));
+
+  {
+    tmpfile.seekp(0, std::ios::beg);    // file pointer position is shared
+
+    std::string content = std::string(std::istreambuf_iterator(tmpfile), {});
+    EXPECT_EQ(content, "Hello, world!");
+  }
+
+  std::ofstream(tmpfile.path(), std::ios::app) << "Goodbye, world!";
+
+  {
+    tmpfile.seekp(0, std::ios::beg);
+
+    std::string content = std::string(std::istreambuf_iterator(tmpfile), {});
+    EXPECT_EQ(content, "Hello, world!Goodbye, world!");
+  }
+}
+
 /// Tests creation of a temporary copy of a file
 TEST(file, copy_file) {
   std::ofstream original = std::ofstream("existing.txt", std::ios::binary);


### PR DESCRIPTION
On Unix systems, we can reliably use `/dev/fd/n` path for getting a path to an opened file