### PR TITLE
Simplify requirements to directory prefixes

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -37,17 +37,17 @@ namespace tmp {
 class TMP_EXPORT directory {
 public:
   /// Creates a unique temporary directory
-  /// @param prefix A prefix to attach to the temporary directory path
+  /// @param prefix A prefix to add to the temporary directory name
   /// @throws std::filesystem::filesystem_error if cannot create a directory
-  /// @throws std::invalid_argument             if the prefix is ill-formatted
+  /// @throws std::invalid_argument if the prefix contains a directory separator
   explicit directory(std::string_view prefix = "");
 
   /// Creates a unique temporary copy recursively from the given path
   /// @param path   A path to make a temporary copy from
-  /// @param prefix A prefix to attach to the temporary directory path
+  /// @param prefix A prefix to add to the temporary directory name
   /// @returns The new temporary directory
   /// @throws std::filesystem::filesystem_error if given path is not a directory
-  /// @throws std::invalid_argument             if the prefix is ill-formatted
+  /// @throws std::invalid_argument if the prefix contains a directory separator
   static directory copy(const std::filesystem::path& path,
                         std::string_view prefix = "");
 

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -1,6 +1,7 @@
 #include "create.hpp"
 
 #include <filesystem>
+#include <iostream>
 #include <stdexcept>
 #include <string_view>
 #include <system_error>
@@ -23,8 +24,10 @@ namespace {
 /// @param[in] prefix The prefix to check validity for
 /// @returns `true` if the prefix is valid, `false` otherwise
 bool is_prefix_valid(const fs::path& prefix) {
-  return prefix.native().find(fs::path::preferred_separator) ==
-         fs::path::string_type::npos;
+  // We also need to check that the prefix does not contain a root path
+  // because of how path concatenation works in C++
+  return prefix.empty() || (++prefix.begin() == prefix.end() &&
+                            prefix.is_relative() && !prefix.has_root_path());
 }
 
 /// Checks if the given prefix is valid to attach to a temporary directory name

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -23,20 +23,17 @@ namespace {
 /// @param[in] prefix The prefix to check validity for
 /// @returns `true` if the prefix is valid, `false` otherwise
 bool is_prefix_valid(const fs::path& prefix) {
-  return prefix.empty() ||
-         (++prefix.begin() == prefix.end() && prefix.is_relative() &&
-          !prefix.has_root_path() && prefix.filename() != "." &&
-          prefix.filename() != "..");
+  return prefix.native().find(fs::path::preferred_separator) ==
+         fs::path::string_type::npos;
 }
 
-/// Checks that the given prefix is valid to attach to a temporary entry path
+/// Checks if the given prefix is valid to attach to a temporary directory name
 /// @param prefix The prefix to check validity for
-/// @throws std::invalid_argument if the prefix cannot be attached to a path
+/// @throws std::invalid_argument if the prefix cannot be attached to the name
 void validate_prefix(const fs::path& prefix) {
   if (!is_prefix_valid(prefix)) {
-    throw std::invalid_argument(
-        "Cannot create a temporary entry: prefix must be empty or a valid "
-        "single-segmented relative pathname");
+    throw std::invalid_argument("Cannot create a temporary directory: prefix "
+                                "must not contain a directory separator");
   }
 }
 

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -16,8 +16,8 @@ namespace fs = std::filesystem;
 /// temporary directory
 /// @param[in] prefix A prefix to attach to the temporary directory name
 /// @returns A path to the created temporary directory
-/// @throws fs::filesystem_error  if cannot create a temporary directory
-/// @throws std::invalid_argument if the prefix is ill-formatted
+/// @throws fs::filesystem_error if cannot create a temporary directory
+/// @throws std::invalid_argument if the prefix contains a directory separator
 fs::path create_directory(std::string_view prefix);
 
 /// Creates a temporary directory with the given prefix in the system's

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -69,14 +69,16 @@ TEST(directory, create_multiple) {
 TEST(directory, create_invalid_prefix) {
   EXPECT_THROW(directory("multi/segment"), std::invalid_argument);
   EXPECT_THROW(directory("/root"), std::invalid_argument);
-  EXPECT_THROW(directory(".."), std::invalid_argument);
-  EXPECT_THROW(directory("."), std::invalid_argument);
 
   fs::path root = fs::temp_directory_path().root_name();
   if (!root.empty()) {
     EXPECT_THROW(directory(root.string() + "relative"), std::invalid_argument);
     EXPECT_THROW(directory(root.string() + "/root"), std::invalid_argument);
   }
+
+#ifdef _WIN32
+  EXPECT_THROW(directory("multi\\segment"), std::invalid_argument);
+#endif
 }
 
 /// Tests creation of a temporary copy of a directory


### PR DESCRIPTION
Since the `directory::directory(std::string_view)` parameter is no longer used as the parent directory name, the names `.` and `..` are no longer disallowed

This means that we can only check the directory separator in the native format of the prefix