### PR TITLE
Reserve some bytes in `directory`

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -85,7 +85,7 @@ private:
   std::filesystem::path pathobject;
 
   /// Memory reserved for future use
-  file::native_handle_type reserved;
+  [[maybe_unused]] file::native_handle_type reserved;
 };
 }    // namespace tmp
 

--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -85,7 +85,7 @@ private:
   std::filesystem::path pathobject;
 
   /// Memory reserved for future use
-  [[maybe_unused]] file::native_handle_type reserved;
+  file::native_handle_type reserved;
 };
 }    // namespace tmp
 

--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -2,6 +2,7 @@
 #define TMP_DIRECTORY_H
 
 #include <tmp/export>
+#include <tmp/file>
 
 #include <filesystem>
 #include <string_view>
@@ -82,6 +83,9 @@ public:
 private:
   /// The managed directory path
   std::filesystem::path pathobject;
+
+  /// Memory reserved for future use
+  file::native_handle_type reserved;
 };
 }    // namespace tmp
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -125,6 +125,7 @@ void directory::move(const fs::path& to) {
 }
 
 directory::~directory() noexcept {
+  (void)reserved;    // Old compilers do not want to accept `[[maybe_unused]]`
   remove(*this);
 }
 


### PR DESCRIPTION
Since Windows can actually prevent open directories from being deleted, and some Linux systems clean up `$TMPDIR` based on advisory BSD locks, the reserved memory is likely to be used to store the handle in the future