### PR TITLE
CI

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
           - macos-15
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
           - macos-15

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -42,7 +42,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
-          - macos-15
+          # - macos-15
     steps:
       - name: Set up `tmpfs` (if supported)
         run: sudo mount tmpfs -t tmpfs -o size=100m /tmp

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - windows-2022
+          - windows-2025
         BUILD_SHARED_LIBS:
           - "TRUE"
           - "FALSE"
@@ -37,7 +37,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - windows-2022
+          - windows-2025
     steps:
       - name: Install Meson
         run: pip install meson ninja

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'tmp',
   'cpp',
-  version: '2.0',
+  version: '3.0',
   default_options: ['cpp_std=c++17'],
 )
 


### PR DESCRIPTION
- Temporarily disable meson build on macos-15 (https://github.com/mesonbuild/meson/issues/13978)
- Migrate to `ubuntu-22.04` instead of `ubuntu-20.04`
- Migrate to `windows-2025` instead of `windows-2022`