### PR TITLE
Hide `create_directory` function overload with `ec`

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -128,38 +128,13 @@ fs::path create_directory(std::string_view prefix, std::error_code& ec) {
   // TODO: open and lock the directory before returning the path
   return path;
 }
-}    // namespace
 
-fs::path create_directory(std::string_view prefix) {
-  validate_prefix(prefix);    // throws std::invalid_argument with a proper text
-
-  std::error_code ec;
-  fs::path directory = create_directory(prefix, ec);
-
-  if (ec) {
-    throw fs::filesystem_error("Cannot create a temporary directory", ec);
-  }
-
-  return directory;
-}
-
-#if defined(_WIN32)
-std::FILE* create_file(std::ios::openmode mode) {
-  std::error_code ec;
-  std::FILE* handle = create_file(mode, ec);
-
-  if (ec) {
-    if (ec == std::errc::invalid_argument) {
-      throw std::invalid_argument(
-          "Cannot create a temporary file: invalid openmode");
-    }
-
-    throw fs::filesystem_error("Cannot create a temporary file", ec);
-  }
-
-  return handle;
-}
-
+#ifdef _WIN32
+/// Creates a temporary file in the system's temporary directory,
+/// and opens it for reading and writing
+/// @param[in]  mode The file opening mode
+/// @param[out] ec   Parameter for error reporting
+/// @returns A handle to the created temporary file
 std::FILE* create_file(std::ios::openmode mode, std::error_code& ec) {
   const wchar_t* mdstr = make_mdstring(mode);
   if (mdstr == nullptr) {
@@ -180,17 +155,10 @@ std::FILE* create_file(std::ios::openmode mode, std::error_code& ec) {
   return handle;
 }
 #else
-int create_file() {
-  std::error_code ec;
-  int handle = create_file(ec);
-
-  if (ec) {
-    throw fs::filesystem_error("Cannot create a temporary file", ec);
-  }
-
-  return handle;
-}
-
+/// Creates a temporary file in the system's temporary directory,
+/// and opens it for reading and writing
+/// @param[out] ec Parameter for error reporting
+/// @returns A handle to the created temporary file
 int create_file(std::error_code& ec) {
   fs::path::string_type path = make_pattern("");
 
@@ -214,6 +182,49 @@ int create_file(std::error_code& ec) {
   //       someone might have created one before we unlinked the file
 
   ec.clear();
+  return handle;
+}
+#endif
+}    // namespace
+
+fs::path create_directory(std::string_view prefix) {
+  validate_prefix(prefix);    // throws std::invalid_argument with a proper text
+
+  std::error_code ec;
+  fs::path directory = create_directory(prefix, ec);
+
+  if (ec) {
+    throw fs::filesystem_error("Cannot create a temporary directory", ec);
+  }
+
+  return directory;
+}
+
+#ifdef _WIN32
+std::FILE* create_file(std::ios::openmode mode) {
+  std::error_code ec;
+  std::FILE* handle = create_file(mode, ec);
+
+  if (ec) {
+    if (ec == std::errc::invalid_argument) {
+      throw std::invalid_argument(
+          "Cannot create a temporary file: invalid openmode");
+    }
+
+    throw fs::filesystem_error("Cannot create a temporary file", ec);
+  }
+
+  return handle;
+}
+#else
+int create_file() {
+  std::error_code ec;
+  int handle = create_file(ec);
+
+  if (ec) {
+    throw fs::filesystem_error("Cannot create a temporary file", ec);
+  }
+
   return handle;
 }
 #endif

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -97,21 +97,12 @@ fs::path make_pattern(std::string_view prefix) {
   return path;
 }
 #endif
-}    // namespace
 
-fs::path create_directory(std::string_view prefix) {
-  validate_prefix(prefix);    // throws std::invalid_argument with a proper text
-
-  std::error_code ec;
-  fs::path directory = create_directory(prefix, ec);
-
-  if (ec) {
-    throw fs::filesystem_error("Cannot create a temporary directory", ec);
-  }
-
-  return directory;
-}
-
+/// Creates a temporary directory with the given prefix in the system's
+/// temporary directory
+/// @param[in]  prefix A prefix to attach to the temporary directory name
+/// @param[out] ec     Parameter for error reporting
+/// @returns A path to the created temporary directory
 fs::path create_directory(std::string_view prefix, std::error_code& ec) {
   if (!is_prefix_valid(prefix)) {
     ec = std::make_error_code(std::errc::invalid_argument);
@@ -136,6 +127,20 @@ fs::path create_directory(std::string_view prefix, std::error_code& ec) {
 
   // TODO: open and lock the directory before returning the path
   return path;
+}
+}    // namespace
+
+fs::path create_directory(std::string_view prefix) {
+  validate_prefix(prefix);    // throws std::invalid_argument with a proper text
+
+  std::error_code ec;
+  fs::path directory = create_directory(prefix, ec);
+
+  if (ec) {
+    throw fs::filesystem_error("Cannot create a temporary directory", ec);
+  }
+
+  return directory;
 }
 
 #if defined(_WIN32)

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -20,13 +20,6 @@ namespace fs = std::filesystem;
 /// @throws std::invalid_argument if the prefix contains a directory separator
 fs::path create_directory(std::string_view prefix);
 
-/// Creates a temporary directory with the given prefix in the system's
-/// temporary directory
-/// @param[in]  prefix A prefix to attach to the temporary directory name
-/// @param[out] ec     Parameter for error reporting
-/// @returns A path to the created temporary directory
-fs::path create_directory(std::string_view prefix, std::error_code& ec);
-
 #if defined(_WIN32)
 /// Creates a temporary file in the system's temporary directory,
 /// and opens it for reading and writing

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -27,27 +27,12 @@ fs::path create_directory(std::string_view prefix);
 /// @returns A handle to the created temporary file
 /// @throws fs::filesystem_error if cannot create a temporary file
 std::FILE* create_file(std::ios::openmode mode);
-
-/// Creates a temporary file in the system's temporary directory,
-/// and opens it for reading and writing
-/// @param[in]  mode The file opening mode
-/// @param[out] ec   Parameter for error reporting
-/// @returns A handle to the created temporary file
-std::FILE* create_file(std::ios::openmode mode, std::error_code& ec);
-#elif __has_include(<unistd.h>)
+#else
 /// Creates a temporary file in the system's temporary directory,
 /// and opens it for reading and writing
 /// @returns A handle to the created temporary file
 /// @throws fs::filesystem_error if cannot create a temporary file
 int create_file();
-
-/// Creates a temporary file in the system's temporary directory,
-/// and opens it for reading and writing
-/// @param[out] ec Parameter for error reporting
-/// @returns A handle to the created temporary file
-int create_file(std::error_code& ec);
-#else
-#error "Target platform not supported"
 #endif
 }    // namespace tmp
 

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -3,7 +3,6 @@
 
 #include <filesystem>
 #include <string_view>
-#include <system_error>
 
 #ifdef _WIN32
 #include <ios>

--- a/src/create.hpp
+++ b/src/create.hpp
@@ -20,12 +20,13 @@ namespace fs = std::filesystem;
 /// @throws std::invalid_argument if the prefix contains a directory separator
 fs::path create_directory(std::string_view prefix);
 
-#if defined(_WIN32)
+#ifdef _WIN32
 /// Creates a temporary file in the system's temporary directory,
 /// and opens it for reading and writing
 /// @param[in] mode The file opening mode
 /// @returns A handle to the created temporary file
 /// @throws fs::filesystem_error if cannot create a temporary file
+/// @throws std::invalid_argument if the given openmode is invalid
 std::FILE* create_file(std::ios::openmode mode);
 #else
 /// Creates a temporary file in the system's temporary directory,


### PR DESCRIPTION
Removed the "public" declaration of the `create_file` and `create_directory` overloads with `std::error_code`