### PR TITLE
Always set `__declspec(dllexport)` for classes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,13 +10,6 @@ include_directory = include_directories('include')
 filesystem_proj = subproject('filesystem')
 filesystem_dep = filesystem_proj.get_variable('filesystem_dep')
 
-default_library = get_option('default_library')
-if default_library != 'static' and host_machine.system() == 'windows'
-  dll_build_args = ['-DTMP_BUILDING_DLL']
-else
-  dll_build_args = []
-endif
-
 tmp = library(
   'tmp',
   'src/create.cpp',
@@ -27,7 +20,6 @@ tmp = library(
   gnu_symbol_visibility: 'hidden',
   version: meson.project_version(),
   dependencies: [filesystem_dep],
-  cpp_args: dll_build_args,
 )
 
 tmp_dep = declare_dependency(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,8 +16,4 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-if(BUILD_SHARED_LIBS)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE TMP_BUILDING_DLL)
-endif()
-
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/src/abi.hpp
+++ b/src/abi.hpp
@@ -1,13 +1,14 @@
 #ifndef TMP_ABI_H
 #define TMP_ABI_H
 
-#if defined _WIN32
+#ifdef _WIN32
 #define abi __declspec(dllexport)
 #else
 #define abi __attribute__((visibility("default")))
 #endif
 
 namespace tmp {
+
 class abi directory;
 class abi file;
 }    // namespace tmp

--- a/src/abi.hpp
+++ b/src/abi.hpp
@@ -2,11 +2,7 @@
 #define TMP_ABI_H
 
 #if defined _WIN32
-#if defined TMP_BUILDING_DLL
 #define abi __declspec(dllexport)
-#else
-#define abi
-#endif
 #else
 #define abi __attribute__((visibility("default")))
 #endif


### PR DESCRIPTION
Apparently you can always specify `dllexport` for library classes on Windows, so this pull request eliminates the need to add the `TMP_BUILDING_DLL` compilation definition