### PR TITLE
Flush buffered input in `file::move`

### DIFF
--- a/include/tmp/file
+++ b/include/tmp/file
@@ -81,8 +81,7 @@ public:
   /// @returns The underlying implementation-defined handle
   native_handle_type native_handle() const noexcept;
 
-  /// Links this file to the given path if it is on the same filesystem,
-  /// or copies it otherwise
+  /// Flushes buffered input and copies this file to the given path
   /// @param to The target path
   /// @throws std::filesystem::filesystem_error if cannot move the file
   void move(const std::filesystem::path& to);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -256,10 +256,15 @@ file::native_handle_type file::native_handle() const noexcept {
 }
 
 void file::move(const fs::path& to) {
+  flush();
   seekg(0, std::ios::beg);
 
-  // FIXME: I couldn't figure out how to create a hard link to a file without
-  //        other hard links, so I just copy it even within the same file system
+  // There is no way to create a hard link to a file without hard links
+  // on POSIX and Windows. The only option is to use `AT_EMPTY_PATH`
+  // with `linkat` on Linux platforms; but given that the file is created
+  // in tmpfs, and the persistent storage where the file is moved
+  // is not in tmpfs, this optimization is useless.
+  // So, we copy the file
 
   std::error_code ec;
   native_handle_type target = open_file(to, /*readonly=*/false, ec);

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -195,7 +195,7 @@ TEST(file, move_to_existing_file) {
 
   {
     file tmpfile = file();
-    tmpfile << "Hello, world!" << std::flush;
+    tmpfile << "Hello, world!";
 
     tmpfile.move(to);
   }


### PR DESCRIPTION
Add a flush call at the beginning of `file::move`