### PR TITLE
Catch all exceptions in `~directory`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: >
   -*-use-default-member-init,
   -*-noexcept-move-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-empty-catch,
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-pro-type-member-init,

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -4,6 +4,7 @@
 #include <tmp/directory>
 
 #include <filesystem>
+#include <iostream>
 #include <new>
 #include <string_view>
 #include <system_error>
@@ -43,13 +44,12 @@ fs::path directory::operator/(const fs::path& source) const {
 directory::~directory() noexcept {
   (void)reserved;    // Old compilers do not want to accept `[[maybe_unused]]`
 
-  if (!path().empty()) {
-    try {
-      std::error_code ec;
-      fs::remove_all(path(), ec);
-    } catch (const std::bad_alloc& ex) {
-      static_cast<void>(ex);
+  try {
+    if (!path().empty()) {
+      fs::remove_all(path());
     }
+  } catch (const std::exception& ex) {
+    std::cerr << "tmp::directory::~directory() error: " << ex.what() << '\n';
   }
 }
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -43,7 +43,11 @@ directory::~directory() noexcept {
 
   try {
     if (!path().empty()) {
-      fs::remove_all(path());
+      // Calling the `std::error_code` overload of `fs::remove_all` should be
+      // more optimal here since it would not require creating
+      // a `fs::filesystem_error` message before we suppress the exception
+      std::error_code ec;
+      fs::remove_all(path(), ec);
     }
   } catch (...) {
     // do nothing

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -51,7 +51,8 @@ directory::~directory() noexcept {
       fs::remove_all(path(), ec);
     }
   } catch (...) {
-    // do nothing
+    // Do nothing: if we failed to delete the temporary directory,
+    // the system should do it later
   }
 }
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 namespace tmp {

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -3,9 +3,7 @@
 
 #include <tmp/directory>
 
-#include <exception>
 #include <filesystem>
-#include <iostream>
 #include <string_view>
 #include <utility>
 
@@ -47,8 +45,8 @@ directory::~directory() noexcept {
     if (!path().empty()) {
       fs::remove_all(path());
     }
-  } catch (const std::exception& ex) {
-    std::cerr << "tmp::directory::~directory() error: " << ex.what() << '\n';
+  } catch (...) {
+    // do nothing
   }
 }
 

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -3,11 +3,10 @@
 
 #include <tmp/directory>
 
+#include <exception>
 #include <filesystem>
 #include <iostream>
-#include <new>
 #include <string_view>
-#include <system_error>
 #include <utility>
 
 namespace tmp {


### PR DESCRIPTION
The standard does not specify that only `bad_alloc` can be thrown from `remove_all`