### PR TITLE
Use `std::tmpfile` in `create_file` on Windows

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -1,8 +1,7 @@
-#define _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS    // NOLINT
 
 #include "create.hpp"
 
-#include <corecrt_io.h>
 #include <fcntl.h>
 #include <filesystem>
 #include <iostream>
@@ -14,10 +13,10 @@
 #define UNICODE
 #include <Windows.h>
 #include <array>
+#include <corecrt_io.h>
 #include <cwchar>
 #else
 #include <cerrno>
-#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -75,7 +75,6 @@ TEST(file, create) {
 
   EXPECT_EQ(file_info.dwVolumeSerialNumber,
             temp_directory_info.dwVolumeSerialNumber);
-  EXPECT_EQ(file_info.nNumberOfLinks, 0);    // Has no hardlinks
 #else
   struct stat file_stat;
   fstat(tmpfile.native_handle(), &file_stat);


### PR DESCRIPTION
Instead of dealing with signals, file permissions and such, delegate it to `std::tmpfile`

After creating the file, we can simply `std::freopen` the file with the desired `openmode`

Part of https://github.com/bugdea1er/tmp/issues/193 for Windows