### PR TITLE
Remove `std::hash` specializations

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -74,12 +74,4 @@ private:
 };
 }    // namespace tmp
 
-/// The template specialization of `std::hash` for `tmp::directory`
-template<> struct std::hash<tmp::directory> {
-  std::size_t operator()(const tmp::directory& directory) const noexcept {
-    // `std::hash<std::filesystem::path>` was not included in the C++17 standard
-    return filesystem::hash_value(directory);
-  }
-};
-
 #endif    // TMP_DIRECTORY_H

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -86,11 +86,4 @@ private:
 };
 }    // namespace tmp
 
-/// The template specialization of `std::hash` for `tmp::file`
-template<> struct std::hash<tmp::file> {
-  std::size_t operator()(const tmp::file& file) const noexcept {
-    return std::hash<tmp::file::native_handle_type>()(file.native_handle());
-  }
-};
-
 #endif    // TMP_FILE_H

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -152,13 +152,5 @@ TEST(directory, swap) {
   EXPECT_EQ(fst.path(), snd_path);
   EXPECT_EQ(snd.path(), fst_path);
 }
-
-/// Tests directory hashing
-TEST(directory, hash) {
-  directory tmpdir = directory();
-  std::hash hash = std::hash<directory>();
-
-  EXPECT_EQ(hash(tmpdir), fs::hash_value(tmpdir.path()));
-}
 }    // namespace
 }    // namespace tmp

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -148,14 +148,5 @@ TEST(file, swap) {
   EXPECT_TRUE(is_open(fst));
   EXPECT_TRUE(is_open(snd));
 }
-
-/// Tests file hashing
-TEST(file, hash) {
-  file tmpfile = file();
-  std::hash hash = std::hash<file>();
-
-  EXPECT_EQ(hash(tmpfile),
-            std::hash<file::native_handle_type>()(tmpfile.native_handle()));
-}
 }    // namespace
 }    // namespace tmp


### PR DESCRIPTION
`std::fstream`, the main inspiration for `file`, does not define a specialization of `std::hash`

Given that storing `file` or `directory` in hashmaps is even less sensible, this pr removes the `hash` specializations