### PR TITLE
Move private declarations to `namespace detail`

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -13,8 +13,10 @@
 
 namespace tmp {
 
+namespace detail {
 extern "C++" std::filesystem::path create_directory(std::string_view prefix);
 extern "C++" void remove_all(const std::filesystem::path& path) noexcept;
+}    // namespace detail
 
 /// tmp::directory is a smart handle that manages a temporary directory,
 /// ensuring its recursive deletion when the handle goes out of scope
@@ -50,7 +52,7 @@ public:
   /// @throws std::filesystem::filesystem_error if cannot create a directory
   /// @throws std::invalid_argument if the prefix contains a directory separator
   explicit directory(std::string_view prefix = "")
-      : pathobject(create_directory(prefix)) {}
+      : pathobject(detail::create_directory(prefix)) {}
 
   directory(const directory&) = delete;
   directory& operator=(const directory&) = delete;
@@ -67,7 +69,7 @@ public:
   /// @param other Another directory that will be moved from
   /// @returns `*this`
   directory& operator=(directory&& other) noexcept {
-    remove_all(*this);
+    detail::remove_all(*this);
     pathobject = std::exchange(other.pathobject, std::filesystem::path());
 
     return *this;
@@ -94,7 +96,7 @@ public:
 
   /// Deletes this directory recursively
   ~directory() noexcept {
-    remove_all(*this);
+    detail::remove_all(*this);
   }
 
 private:

--- a/include/tmp/file
+++ b/include/tmp/file
@@ -20,17 +20,14 @@
 
 namespace tmp {
 
-/// Implementation-defined handle type to the file
-#if defined(_WIN32)
-using file_native_handle = void*;    // HANDLE
-#elif __has_include(<unistd.h>)
-using file_native_handle = int;    // POSIX file descriptor
-#else
-#error "Target platform not supported"
-#endif
-
+namespace detail {
 extern "C++" std::FILE* create_file();
-extern "C++" file_native_handle get_native_handle(std::FILE* file) noexcept;
+#if defined(_WIN32)
+extern "C++" void* get_native_handle(std::FILE* file) noexcept;
+#elif __has_include(<unistd.h>)
+extern "C++" int get_native_handle(std::FILE* file) noexcept;
+#endif
+}    // namespace detail
 
 /// tmp::file is a smart handle that manages a binary temporary file, ensuring
 /// its deletion when the handle goes out of scope
@@ -68,13 +65,14 @@ template<class charT, class traits = std::char_traits<charT>>
 class basic_file : public std::basic_iostream<charT, traits> {
 public:
   /// Implementation-defined handle type to the file
-  using native_handle_type = file_native_handle;
+  using native_handle_type =
+      std::invoke_result_t<decltype(detail::get_native_handle), std::FILE*>;
 
   /// Creates and opens a binary temporary file as if by POSIX `tmpfile`
   /// @throws std::filesystem::filesystem_error if cannot create a file
   explicit basic_file()
       : std::basic_iostream<charT, traits>(std::addressof(sb)),
-        underlying(create_file(), &std::fclose),
+        underlying(detail::create_file(), &std::fclose),
         sb(open_filebuf(underlying.get())) {}
 
   basic_file(const basic_file&) = delete;
@@ -100,7 +98,7 @@ public:
   /// Returns an implementation-defined handle to this file
   /// @returns The underlying implementation-defined handle
   native_handle_type native_handle() const noexcept {
-    return get_native_handle(underlying.get());
+    return detail::get_native_handle(underlying.get());
   }
 
   /// Closes and deletes this file
@@ -128,7 +126,7 @@ private:
 #if defined(_MSC_VER)
     sb = std::basic_filebuf<charT, traits>(file);
 #elif defined(_LIBCPP_VERSION)
-    sb.__open(get_native_handle(file), mode);
+    sb.__open(detail::get_native_handle(file), mode);
 #else
     sb = __gnu_cxx::stdio_filebuf<charT, traits>(file, mode);
 #endif

--- a/src/abi.hpp
+++ b/src/abi.hpp
@@ -14,7 +14,7 @@
 #define abi __attribute__((visibility("default")))
 #endif
 
-namespace tmp {
+namespace tmp::detail {
 
 auto abi create_directory(std::string_view prefix) -> std::filesystem::path;
 auto abi remove_all(const std::filesystem::path& path) noexcept -> void;
@@ -25,7 +25,9 @@ auto abi get_native_handle(std::FILE* file) noexcept ->
     void*;
 #elif __has_include(<unistd.h>)
     int;
+#else
+#error "Target platform not supported"
 #endif
-}    // namespace tmp
+}    // namespace tmp::detail
 
 #endif    // TMP_ABI_H

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -20,7 +20,7 @@
 #include <unistd.h>
 #endif
 
-namespace tmp {
+namespace tmp::detail {
 namespace {
 
 namespace fs = std::filesystem;
@@ -112,4 +112,4 @@ void remove_all(const fs::path& path) noexcept {
     // the system should do it later
   }
 }
-}    // namespace tmp
+}    // namespace tmp::detail

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -17,7 +17,7 @@
 #include <io.h>
 #endif
 
-namespace tmp {
+namespace tmp::detail {
 
 namespace fs = std::filesystem;
 
@@ -52,4 +52,4 @@ file::native_handle_type get_native_handle(std::FILE* file) noexcept {
   return fileno(file);
 #endif
 }
-}    // namespace tmp
+}    // namespace tmp::detail


### PR DESCRIPTION
Functions used in the inline function bodies should not be used by end users