### PR TITLE
Return canonical path from `directory::path`

### DIFF
--- a/include/tmp/directory
+++ b/include/tmp/directory
@@ -76,13 +76,13 @@ public:
   }
 
   /// Returns the path of this directory
-  /// @returns The full path of this directory
+  /// @returns The canonical path of this directory
   operator const std::filesystem::path&() const noexcept {
     return pathobject;
   }
 
   /// Returns the path of this directory
-  /// @returns The full path of this directory
+  /// @returns The canonical path of this directory
   const std::filesystem::path& path() const noexcept {
     return pathobject;
   }

--- a/src/create_directory.cpp
+++ b/src/create_directory.cpp
@@ -90,6 +90,6 @@ fs::path create_directory(std::string_view prefix) {
     throw fs::filesystem_error("Cannot create a temporary directory", ec);
   }
 
-  return path;
+  return fs::canonical(path);
 }
 }    // namespace tmp::detail

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -30,6 +30,8 @@ TEST(directory, create_with_prefix) {
   EXPECT_TRUE(fs::is_directory(tmpdir));
   EXPECT_TRUE(fs::equivalent(parent, fs::temp_directory_path()));
 
+  EXPECT_EQ(fs::canonical(tmpdir), tmpdir.path());
+
 #ifdef _WIN32
   constexpr std::wstring_view actual_prefix = L"com.github.bugdea1er.tmp.";
 #else


### PR DESCRIPTION
The `directory::path()` and `directory::operator const path&()` functions are now guaranteed to return the absolute canonical directory path, rather than a raw (potentially non-normalized) path.

This, for example, allows opening files in a temporary directory using the `O_NOFOLLOW_ANY` option in user programs.