### PR TITLE
Respect TMP environment variables for tmp::file on POSIX

### DIFF
--- a/src/create_file.cpp
+++ b/src/create_file.cpp
@@ -12,6 +12,8 @@
 #include <system_error>
 
 #if __has_include(<unistd.h>)
+#include <sys/fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
@@ -19,13 +21,26 @@ namespace tmp::detail {
 
 namespace fs = std::filesystem;
 
-/// Creates and opens a binary temporary file as if by POSIX `tmpfile`
-/// @returns A pointer to the file stream associated with the temporary file
-/// @throws fs::filesystem_error if cannot create a temporary file
-std::FILE* create_file() {
+namespace {
+
 #if __has_include(<unistd.h>)
-  std::string path = fs::temp_directory_path() / "XXXXXX";
-  int descriptor   = mkstemp(path.data());
+/// Creates and opens a binary temporary file as if by POSIX `mkstemp`
+/// @returns A file descriptor associated with the temporary file
+/// @throws fs::filesystem_error if cannot create a temporary file
+int create_file_descriptor() {
+  fs::path temp_dir = fs::temp_directory_path();
+  int descriptor    = int{};
+
+#ifdef __linux__
+  descriptor = open(temp_dir.c_str(), O_RDWR | O_TMPFILE, S_IRUSR | S_IWUSR);
+  if (descriptor >= 0) {
+    return descriptor;
+  }
+#endif
+
+  std::string path = temp_dir / "XXXXXX";
+
+  descriptor = mkstemp(path.data());
   if (descriptor == -1) {
     std::error_code ec = std::error_code(errno, std::system_category());
     throw fs::filesystem_error("Cannot create a temporary file", ec);
@@ -33,10 +48,24 @@ std::FILE* create_file() {
 
   unlink(path.data());
 
+  return descriptor;
+}
+#endif
+}    // namespace
+
+/// Creates and opens a binary temporary file as if by POSIX `tmpfile`
+/// @returns A pointer to the file stream associated with the temporary file
+/// @throws fs::filesystem_error if cannot create a temporary file
+std::FILE* create_file() {
+#if __has_include(<unistd.h>)
+  int descriptor = create_file_descriptor();
+
+  // TODO: let `filebuf` use the file descriptor without `FILE` wrapping
   std::FILE* file = fdopen(descriptor, "wb+");
   if (file == nullptr) {
     std::error_code ec = std::error_code(errno, std::system_category());
     close(descriptor);
+
     throw fs::filesystem_error("Cannot create a temporary file", ec);
   }
 #else

--- a/src/create_file.cpp
+++ b/src/create_file.cpp
@@ -27,7 +27,7 @@ std::FILE* create_file() {
   std::string path = fs::temp_directory_path() / "XXXXXX";
   int descriptor   = mkstemp(path.data());
   if (descriptor == -1) {
-    std::error_code ec = std::error_code(errno, std::generic_category());
+    std::error_code ec = std::error_code(errno, std::system_category());
     throw fs::filesystem_error("Cannot create a temporary file", ec);
   }
 
@@ -35,7 +35,7 @@ std::FILE* create_file() {
 
   std::FILE* file = fdopen(descriptor, "wb+");
   if (file == nullptr) {
-    std::error_code ec = std::error_code(errno, std::generic_category());
+    std::error_code ec = std::error_code(errno, std::system_category());
     close(descriptor);
     throw fs::filesystem_error("Cannot create a temporary file", ec);
   }

--- a/src/create_file.cpp
+++ b/src/create_file.cpp
@@ -10,6 +10,10 @@
 #include <filesystem>
 #include <system_error>
 
+#if __has_include(<unistd.h>)
+#include <unistd.h>
+#endif
+
 namespace tmp::detail {
 
 namespace fs = std::filesystem;
@@ -18,11 +22,29 @@ namespace fs = std::filesystem;
 /// @returns A pointer to the file stream associated with the temporary file
 /// @throws fs::filesystem_error if cannot create a temporary file
 std::FILE* create_file() {
+#if __has_include(<unistd.h>)
+  std::string path = fs::temp_directory_path() / "XXXXXX";
+  int descriptor   = mkstemp(path.data());
+  if (descriptor == -1) {
+    std::error_code ec = std::error_code(errno, std::generic_category());
+    throw fs::filesystem_error("Cannot create a temporary file", ec);
+  }
+
+  unlink(path.data());
+
+  std::FILE* file = fdopen(descriptor, "wb+");
+  if (file == nullptr) {
+    std::error_code ec = std::error_code(errno, std::generic_category());
+    close(descriptor);
+    throw fs::filesystem_error("Cannot create a temporary file", ec);
+  }
+#else
   std::FILE* file = std::tmpfile();
   if (file == nullptr) {
     std::error_code ec = std::error_code(errno, std::generic_category());
     throw fs::filesystem_error("Cannot create a temporary file", ec);
   }
+#endif
 
   return file;
 }

--- a/src/create_file.cpp
+++ b/src/create_file.cpp
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <filesystem>
+#include <string>
 #include <system_error>
 
 #if __has_include(<unistd.h>)

--- a/tests/directory.cpp
+++ b/tests/directory.cpp
@@ -7,7 +7,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <ios>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -107,10 +107,10 @@ TYPED_TEST(file, create) {
 
   EXPECT_EQ(file_info.dwVolumeSerialNumber, dir_info.dwVolumeSerialNumber);
 #else
-  struct stat file_stat{};
+  struct stat file_stat {};
   ASSERT_EQ(fstat(handle, &file_stat), 0);
 
-  struct stat dir_stat{};
+  struct stat dir_stat {};
   ASSERT_EQ(stat(temp_dir.c_str(), &dir_stat), 0);
 
   EXPECT_EQ(file_stat.st_dev, dir_stat.st_dev);

--- a/tests/file.cpp
+++ b/tests/file.cpp
@@ -11,7 +11,6 @@
 #include <istream>
 #include <iterator>
 #include <ostream>
-#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -20,10 +19,13 @@
 #include <Windows.h>
 #else
 #include <fcntl.h>
+#include <sys/stat.h>
 #endif
 
 namespace tmp {
 namespace {
+
+namespace fs = std::filesystem;
 
 /// Test fixture for `basic_file` tests
 template<class charT> class file : public testing::Test {
@@ -85,6 +87,34 @@ TYPED_TEST(file, create) {
   basic_file<TypeParam> tmpfile = basic_file<TypeParam>();
   EXPECT_TRUE(TestFixture::is_open(tmpfile.rdbuf()));
   EXPECT_TRUE(TestFixture::is_open(tmpfile.native_handle()));
+
+  fs::path temp_dir = fs::temp_directory_path();
+  auto handle       = tmpfile.native_handle();
+
+#ifdef _WIN32
+  BY_HANDLE_FILE_INFORMATION file_info;
+  ASSERT_TRUE(GetFileInformationByHandle(handle, &file_info));
+
+  HANDLE dir_handle =
+      CreateFileW(temp_dir.c_str(), FILE_READ_ATTRIBUTES,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+  ASSERT_NE(dir_handle, INVALID_HANDLE_VALUE);
+
+  BY_HANDLE_FILE_INFORMATION dir_info;
+  ASSERT_TRUE(GetFileInformationByHandle(dir_handle, &dir_info));
+  CloseHandle(dir_handle);
+
+  EXPECT_EQ(file_info.dwVolumeSerialNumber, dir_info.dwVolumeSerialNumber);
+#else
+  struct stat file_stat{};
+  ASSERT_EQ(fstat(handle, &file_stat), 0);
+
+  struct stat dir_stat{};
+  ASSERT_EQ(stat(temp_dir.c_str(), &dir_stat), 0);
+
+  EXPECT_EQ(file_stat.st_dev, dir_stat.st_dev);
+#endif
 }
 
 /// Tests multiple file creation


### PR DESCRIPTION
Unfortunately std::tmpfile doesn't respect TMPDIR, TMP, and other environment variables for base tmp directories  
Implementation mirrors glibc's tmpfile but uses std::filesystem::temp_directory_path to get correct base path
https://sourceware.org/git/?p=glibc.git;a=blob;f=stdio-common/tmpfile.c